### PR TITLE
Remove dates from Concise Guides

### DIFF
--- a/docs/Concise-Guide-for-Developing-More-Secure-Software.md
+++ b/docs/Concise-Guide-for-Developing-More-Secure-Software.md
@@ -1,4 +1,4 @@
-# Concise Guide for Developing More Secure Software 2023-01-03
+# Concise Guide for Developing More Secure Software
 
 Here is a concise guide for all software developers for software development, building, and distribution. All tools or services listed are merely examples.
 

--- a/docs/Concise-Guide-for-Evaluating-Open-Source-Software.md
+++ b/docs/Concise-Guide-for-Evaluating-Open-Source-Software.md
@@ -1,4 +1,4 @@
-# Concise Guide for Evaluating Open Source Software 2023-01-03
+# Concise Guide for Evaluating Open Source Software
 
 As a software developer, before using open source software (OSS) dependencies or tools, identify candidates and evaluate the leading ones against your needs. To evaluate a potential OSS dependency for security and sustainability, consider these questions (all tools or services listed are merely examples):
 


### PR DESCRIPTION
The concise guides are already under version control, we don't need a date (that will itself go out of date).