### PR TITLE
Add sample hyperlink for -fstack-protector-strong

### DIFF
--- a/docs/Compiler_Hardening_Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler_Hardening_Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -62,7 +62,7 @@ Table 2: Recommended compiler options that enable run-time protection mechanisms
 |:----------------------------------------------------- |:----------------------------------:|:-------------------------------------------------------------------------------------------- |
 | `-D_FORTIFY_SOURCE=2` <br/>(requires `-O1` or higher) |      GCC 4.0<br/>Clang 5.0.0       | Fortify sources with compile- and run-time checks for unsafe libc usage and buffer overflows |
 | `-fstack-clash-protection`                            |       GCC 8<br/>Clang 11.0.0       | Enable run-time checks for variable-size stack allocation validity                           |
-| `-fstack-protector-strong`                            |     GCC 4.9.0<br/>Clang 5.0.0      | Enable run-time checks for stack-based buffer overflows                                      |
+| [`-fstack-protector-strong`](#-fstack-protector-strong)                            |     GCC 4.9.0<br/>Clang 5.0.0      | Enable run-time checks for stack-based buffer overflows                                      |
 | `-Wl,-z,nodlopen`<br/>`-Wl,-z,nodump`                 |           Binutils 2.10            | Restrict `dlopen(3)` and `dldump(3)` calls to shared objects                                 |
 | `-Wl,-z,noexecstack`<br/>`-Wl,-z,noexecheap`          |           Binutils 2.14            | Enable data execution prevention by marking stack and heap memory as non-executable          |
 | `-Wl,-z,relro`<br/>`-Wl,-z,now`                       |           Binutils 2.15            | Mark relocation table entries resolved at load- time as read-only                            |
@@ -223,7 +223,7 @@ Note that `vm.heap-stack-gap` expresses the gap as multiple of page size whereas
 
 | Compiler Flag                                             |       Supported by        | Description                                                                                                      |
 |:--------------------------------------------------------- |:-------------------------:|:---------------------------------------------------------------------------------------------------------------- |
-| `-fstack-protector-strong`                                | GCC 4.9.0<br/>Clang 5.0.0 | Enable run-time checks for stack-based buffer overflows using strong heuristic                                   |
+| <span id="-fstack-protector-strong">`-fstack-protector-strong`</span>                                | GCC 4.9.0<br/>Clang 5.0.0 | Enable run-time checks for stack-based buffer overflows using strong heuristic                                   |
 | `-fstack-protector-all`                                   |       GCC<br/>Clang       | Enable run-time checks for stack-based buffer overflows for all functions                                        |
 | `-fstack-protector`<br/>`--param=ssp-buffer-size=`_`<n>`_ |       GCC<br/>Clang       | Enable run-time checks for stack-based buffer overflows for functions with character arrays if _n_ or more bytes |
 


### PR DESCRIPTION
It would be nice if readers could click on a compiler flag in a summary and immediately see the details about that flag.

I propose adding hyperlinks to implement that. It would make the markdown a *little* messier, but not outrageously so, and it would make the document *much* easier to navigate. I think we need to make it *easy* for readers to get from a summary to the details they need, or they won't read the details they need.

This adds an internal hyperlink from a flag description in a summary to an anchor on the details. The anchor is a span with id; I could have used a name="..." instead, but many seem to be preferring id so I used that. The id is exactly the flag name (e.g., `-fstack-protector-strong`); leading dashes *are* allowed in ids.

NB: The sample entry makes 1 table entry longer than the others; if they *all* do that, then columns could be re-aligned again without lots of space.