### PR TITLE
Tweak introduction of compiler options guide

### DIFF
--- a/docs/Compiler_Hardening_Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler_Hardening_Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -1,10 +1,10 @@
 # Compiler Options Hardening Guide for C and C++
 
-This document is intended as a general overview of compiler and linker options that contribute to delivering reliable and secure code using native (or cross) toolchains for C and C++. The objective of compiler options hardening is to produce application binaries (executables) with security mechanisms against potential attacks and/or misbehavior.
+This document is a guide for compiler and linker options that contribute to delivering reliable and secure code using native (or cross) toolchains for C and C++. The objective of compiler options hardening is to produce application binaries (executables) with security mechanisms against potential attacks and/or misbehavior.
 
 Hardened compiler options should also produce applications that integrate well with existing platform security features in modern operating systems (OSs). Effectively configuring the compiler options also has several benefits during development such as enhanced compiler warnings, static analysis, and debug instrumentation.
 
-This document focuses on recommended options for the GNU Compiler Collection (GCC) and clang, and we expect to expand it to cover compilers that have similar options (such as the Intel C++ compiler).
+This document focuses on recommended options for the GNU Compiler Collection (GCC) and clang, and we expect to expand it to cover compilers that have similar option syntax (such as the Intel C++ compiler).
 
 **TL;DR: What compiler options should I use?**
 
@@ -19,7 +19,9 @@ When compiling C or C++ code on compilers such as GCC and clang, turn on these f
 -fPIE -pie -fPIC -shared
 ~~~~
 
-Developers should use `-Werror`, but redistributors will probably want to omit `-Werror`. See the discussion below a background and for detailed discussion of each option.
+Developers should use `-Werror`, but redistributors will probably want to omit `-Werror`. Developers who release source code should ensure that their programs compile and pass their automated tests with all these options, e.g., by setting these as the default options. We encourage developers to consider it a bug if the program cannot be compiled with these options. Those who build programs for production may choose to omit some options that hurt performance if the program only processes trusted data, but remember that it's not helpful to deploy programs that that are insecure and.rapidly do the wrong thing. Existing programs may need to be modified over time to work with some of these options.
+
+See the discussion below a background and for detailed discussion of each option.
 
 **Why do we need compiler options hardening?**
 


### PR DESCRIPTION
This adds some information from the old version, and makes it clear we encourage developers to treat not supporting these compiler options as a problem.