### PR TITLE
Fix incorrect level in _FORTIFY_SOURCE mode of operation description

### DIFF
--- a/docs/Compiler_Hardening_Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler_Hardening_Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -232,7 +232,7 @@ The `_FORTIFY_SOURCE` mechanisms have three modes of operation:
 
 - `-D_FORTIFY_SOURCE=1`: conservative, compile-time and runtime checks; will not change (defined) behavior of programs. Checking for overflows is enabled when the compiler is able to estimate a compile time constant size for the protected object.
 - `-D_FORTIFY_SOURCE=2`: stricter checks that also detect behavior that may be unsafe even though it conforms to the C standard; may affect program behavior by disallowing certain programming constructs. An example of such checks is restricting of the `%n` format specifier to read-only format strings.
-- `-D_FORTIFY_SOURCE=3`: Same checks as those covered by `-D_FORTIFY_SOURCE=3` except that checking is enabled even when the compiler is able to estimate the size of the protected object as an expression, not just a compile time constant.
+- `-D_FORTIFY_SOURCE=3`: Same checks as those covered by `-D_FORTIFY_SOURCE=2` except that checking is enabled even when the compiler is able to estimate the size of the protected object as an expression, not just a compile time constant.
 
 To benefit from `_FORTIFY_SOURCE` checks following requirements must be met:  
 


### PR DESCRIPTION
The description of the` _FORTIFY_SOURCE=3` mode of operation incorrectly refers to 'same checks as those covered by `_FORTIFY_SOURCE=3`' when it should presumably refer to 'same checks as those covered by `_FORTIFY_SOURCE=2`'.

This PR changes the wording to correctly refer to `_FORTIFY_SOURCE=2`