### PR TITLE
Add an index.md to /docs of "released work"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# OpenSSF Best Practices Working Group (WG)
+
+This is a list of materials (documents, services, and so on) released by the
+[Open Source Security Foundation (OpenSSF)](https;//openssf.org)
+[Best Practices Working Group (WG)].
+
+## Guides
+
+* [Concise Guide for Developing More Secure Software](https://best.openssf.org/Concise-Guide-for-Developing-More-Secure-Software)
+* [Concise Guide for Evaluating Open Source Software](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software)
+* [npm Best Practices Guide](https://github.com/ossf/package-manager-best-practices/blob/main/published/npm.md)
+
+Note: You can also see the larger list of
+[Guides released by the OpenSSF](https://openssf.org/resources/guides/).
+
+## Educational materials
+
+[Secure Software Development Fundamentals Courses](https://openssf.org/training/courses/) - a course for software developers focusing on the fundamentals of developing secure software (open source software or proprietary software).
+
+## OSS Project Evaluation
+
+* [Security Scorecard](https://github.com/ossf/scorecard) - automated scoring of OSS projects
+* [OpenSSF Best Practices badge](https://bestpractices.coreinfrastructure.org/) - a way for Free/Libre/Open Source Software projects to show that they follow best practices (you can also see its [source code repository](https://github.com/coreinfrastructure/best-practices-badge)).
+
+## Future work
+
+The OpenSSF Best Practices WG is working on many more materials, such as
+more educational materials through our education special interest group (SIG),
+compiler hardening guides,
+guidance about memory safety through our memory safety SIG, and so on.
+
+[Please join the OpenSSF Best Practices working group if you're interested in helping](https://github.com/ossf/wg-best-practices-os-developers)!
+
+Please also see the
+[main OpenSSF website](https://openssf.org)
+to learn more about the OpenSSF.


### PR DESCRIPTION
Add an "index.md" file so that people can view
<https://best.openssf.org> and see all the *released* work from the OpenSSF Best Practices Working Group.

The goal is to make this more discoverable.

We *separately* need to create a "landing page" for developers, one that would cover all OpenSSF work (at least).
That is a *separate* idea, I currently expect that to be developed in `./developer.md`. But let's quickly get this "general list" added, so it'll be easy to find this info!