### PR TITLE
Omit leading slash in _config.yml path

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,11 +20,11 @@ defaults:
       author: Open Source Security Foundation (OpenSSF)
   -
     scope:
-      path: "/Concise-Guide-for-Developing-More-Secure-Software.html"
+      path: "Concise-Guide-for-Developing-More-Secure-Software.html"
     values:
       description: This is a concise guide for all software developers for how to create more secure software during development, building, and distribution.
   -
     scope:
-      path: "/Concise-Guide-for-Evaluating-Open-Source-Software.html"
+      path: "Concise-Guide-for-Evaluating-Open-Source-Software.html"
     values:
       description: This is a concise guide for evaluating Open Source Software (OSS) for its security and sustainability.


### PR DESCRIPTION
It turns out that the _config.yml path value
doesn't use a leading "/" when referring to files. Remove it. See:
https://jekyllrb.com/docs/configuration/front-matter-defaults/

This will let us set the descriptions of individual files *without* adding a yml header to the markdown itself. Currently people are jumping directly to the markdown, so we want the markdown as readable as we can make it until people generally use the publishing website best.opennsf.org.