### PR TITLE
In _config.yml use glob in path

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,11 +20,11 @@ defaults:
       author: Open Source Security Foundation (OpenSSF)
   -
     scope:
-      path: "Concise-Guide-for-Developing-More-Secure-Software.html"
+      path: "Concise-Guide-for-Developing-More-Secure-Software*"
     values:
       description: This is a concise guide for all software developers for how to create more secure software during development, building, and distribution.
   -
     scope:
-      path: "Concise-Guide-for-Evaluating-Open-Source-Software.html"
+      path: "Concise-Guide-for-Evaluating-Open-Source-Software*"
     values:
       description: This is a concise guide for evaluating Open Source Software (OSS) for its security and sustainability.


### PR DESCRIPTION
The override of the description isn't working.
Modify the _config.yml file so the path uses a glob; this may slow builds slightly, but hopefully it will mean the pattern matches and sets the description.