### PR TITLE
Compiler guide: adding minimal infos to empty readme

### DIFF
--- a/docs/Compiler-Hardening-Guides/README.md
+++ b/docs/Compiler-Hardening-Guides/README.md
@@ -1,11 +1,21 @@
 # Compiler Hardening Guides
 
-This is the working area for the C/C++ Compiler hardening best practices guide.  Items here are currently in DRAFT.
+This is the working area for the C/C++ Compiler hardening best practices guide.  This document is currently work-in-progress and in incubation state.
 
-~~~~text
-How to collaborate
+## Scope and Objectives
 
+This document is a guide for compiler and linker options that contribute to delivering reliable and secure code using native (or cross) toolchains for C and C++.
+The objective of compiler options hardening is to produce application binaries (executables) with security mechanisms against potential attacks and/or misbehavior.
 
-~~~~
+## How to Contribute
 
-15Feb2023
+Contributions to the guide are always welcome, for instance:
+
+* documentation of additional, currently not yet covered, compiler options which improve the security of binaries,
+* documentation of similar/equivalent options of other (widely used) compilers which are currently not yet covered by this guide,
+* improvements of the existing text
+
+The group of authors meets online every other week to discuss open items and work on the doucment.
+The [meeting details](https://github.com/ossf/wg-best-practices-os-developers/tree/main#meeting-times) can be found in the main [README](https://github.com/ossf/wg-best-practices-os-developers/blob/main/README.md) of the Best Practices Working Group.
+
+Pull requests as always welcome!


### PR DESCRIPTION
The readme file in the directory of the hardening guide is mainly empty. This PR adds minimal information about the effort and how to get involved.