### PR TITLE
Change "Server" to "Enterprise"

### DIFF
--- a/docs/SCM-BestPractices/README.md
+++ b/docs/SCM-BestPractices/README.md
@@ -10,20 +10,15 @@ Collaborative source code management platforms (such as GitHub and GitLab) play 
 
 This guide has been written for the:
 
-* **Maintainer** who wants to improve the security posture for one or more GitHub repositories or GitLab projects they support.  
+* **Maintainer** who wants to improve the security posture for one or more GitHub repositories or GitLab projects they support.
+* **Owner** who wants to improve the security posture for their GitHub organization or GitLab group they manage. 
 * **Open Source Program Office (OSPO)** (or a team that plays a similar role) who is typically responsible for multiple GitHub organizations or GitLab groups.
 * **Operations** team tasked with applying policies as part of their work managing assets on these platforms.
+* **GitHub/GitLab server administrator** who wants to improve the security posture for their SCM server. 
 
 ## Tooling
 
 Below is a non-exhaustive list of possible tools that can be used to assist in review source code repositories.
-
-### Allstar - <https://github.com/ossf/allstar>
-
-An open-source project from the [OpenSSF](https://openssf.org/) that scans GitHub organizations for “repository level” misconfigurations.
-Allstar detects a subset of the “repository level” policies suggested by this document. It can be configured to scan all repositories in an organization or a subset of them and is supported by the following SCMs:
-
-* GitHub Cloud
 
 ### Legitify - <https://github.com/Legit-Labs/legitify>
 
@@ -34,6 +29,13 @@ Legitify detects all policies suggested by this document and supports the follow
 * GitHub Enterprise Server
 * GitLab Cloud
 * GitLab Server
+
+### Allstar - <https://github.com/ossf/allstar>
+
+An open-source project from the [OpenSSF](https://openssf.org/) that scans GitHub organizations for “repository level” misconfigurations.
+Allstar detects a subset of the “repository level” policies suggested by this document. It can be configured to scan all repositories in an organization or a subset of them and is supported by the following SCMs:
+
+* GitHub Cloud
 
 ### Scorecard - <https://github.com/ossf/scorecard>
 
@@ -63,7 +65,7 @@ For recmmendations only applicable to GitHub or GitLab visit one of the followin
 * Runner Group Should Be Limited to Private Repositories [<img src="https://user-images.githubusercontent.com/287526/230375178-2f1f8844-5609-4ef3-b9ac-141c20c43406.svg" alt="GitHub" height="20" width="20">](github/runner_group/runner_group_can_be_used_by_public_repositories.md)
 * Runner Group Should Be Limited to Selected Repositories [<img src="https://user-images.githubusercontent.com/287526/230375178-2f1f8844-5609-4ef3-b9ac-141c20c43406.svg" alt="GitHub" height="20" width="20">](github/runner_group/runner_group_not_limited_to_selected_repositories.md)
 
-### Server
+### Enterprise
 
 * Two-Factor Authentication Should Be Enforced For The Enterprise [<img src="https://user-images.githubusercontent.com/287526/230375178-2f1f8844-5609-4ef3-b9ac-141c20c43406.svg" alt="GitHub" height="20" width="20">](github/enterprise/enterprise_enforce_two_factor_authentication.md)
 * Enterprise Should Not Allow Members To Create public Repositories [<img src="https://user-images.githubusercontent.com/287526/230375178-2f1f8844-5609-4ef3-b9ac-141c20c43406.svg" alt="GitHub" height="20" width="20">](github/enterprise/enterprise_allows_creating_public_repos.md)
@@ -161,5 +163,5 @@ The following community members helped contribute to this guidance:
 * [Chris de Almeida, IBM](https://github.com/ctcpip)
 * [Christine Abernathy, F5 - project lead](https://github.com/caabernathy)
 * [Daniel Appelquist, Snyk - project lead](https://github.com/Torgo)
-* [Noam Dotan, Legit Security - project lead](https://github.com/)
+* [Noam Dotan, Legit Security - project lead](https://github.com/noamd-legit)
 * [David A. Wheeler, The Linux Foundation](https://github.com/david-a-wheeler)

--- a/docs/SCM-BestPractices/README.md
+++ b/docs/SCM-BestPractices/README.md
@@ -14,7 +14,7 @@ This guide has been written for the:
 * **Owner** who wants to improve the security posture for their GitHub organization or GitLab group they manage. 
 * **Open Source Program Office (OSPO)** (or a team that plays a similar role) who is typically responsible for multiple GitHub organizations or GitLab groups.
 * **Operations** team tasked with applying policies as part of their work managing assets on these platforms.
-* **GitHub/GitLab server administrator** who wants to improve the security posture for their SCM server. 
+* **GitHub/GitLab enterprise administrator** who wants to improve the security posture for their SCM enterprise. 
 
 ## Tooling
 

--- a/docs/SCM-BestPractices/github/README.md
+++ b/docs/SCM-BestPractices/github/README.md
@@ -23,8 +23,7 @@ organizations they manage.
 multiple organizations and repositories.
 * **Operations** team tasked with applying policies as part of their work
 managing assets on GitHub.
-* **GitHub Enterprise Server admin** who wants to improve the security posture
-for their server. 
+* **GitHub Enterprise administrator** who wants to improve the security posture for their enterprise.
 
 ## Recommendations
 

--- a/docs/SCM-BestPractices/github/README.md
+++ b/docs/SCM-BestPractices/github/README.md
@@ -17,10 +17,14 @@ This guide has been written for the:
 
 * **Maintainer** who wants to improve the security posture for one or more
 GitHub repositories they support.
+* **Owner** who wants to improve the security posture for one or more GitHub
+organizations they manage. 
 * **Open Source Program Office (OSPO)** who is typically responsible for
 multiple organizations and repositories.
 * **Operations** team tasked with applying policies as part of their work
 managing assets on GitHub.
+* **GitHub Enterprise Server admin** who wants to improve the security posture
+for their server. 
 
 ## Recommendations
 
@@ -33,7 +37,7 @@ managing assets on GitHub.
 5. [Runner Group Should Be Limited to Private Repositories](runner_group/runner_group_can_be_used_by_public_repositories.md)
 6. [Runner Group Should Be Limited to Selected Repositories](runner_group/runner_group_not_limited_to_selected_repositories.md)
 
-### Server
+### Enterprise
 
 1. [Two-Factor Authentication Should Be Enforced For The Enterprise](enterprise/enterprise_enforce_two_factor_authentication.md)
 2. [Enterprise Should Not Allow Members To Change Repository Visibility](enterprise/enterprise_not_using_visibility_change_disable_policy.md)

--- a/docs/SCM-BestPractices/gitlab/README.md
+++ b/docs/SCM-BestPractices/gitlab/README.md
@@ -23,7 +23,7 @@ groups they manage.
 multiple groups and projects.
 * **Operations** team tasked with applying policies as part of their work
 managing assets on GitLab.
-* **GitLab server admin** who wants to improve the security posture for their server. 
+* **GitLab enterprise admin** who wants to improve the security posture for their server. 
 
 ## Recommendations
 

--- a/docs/SCM-BestPractices/gitlab/README.md
+++ b/docs/SCM-BestPractices/gitlab/README.md
@@ -17,14 +17,17 @@ This guide has been written for the:
 
 * **Maintainer** who wants to improve the security posture for one or more
 GitLab projects they support.
+* **Owner** who wants to improve the security posture for one or more GitLab
+groups they manage. 
 * **Open Source Program Office (OSPO)** who is typically responsible for
 multiple groups and projects.
 * **Operations** team tasked with applying policies as part of their work
 managing assets on GitLab.
+* **GitLab server admin** who wants to improve the security posture for their server. 
 
 ## Recommendations
 
-## Server
+## Enterprise
 
 1. [Two-Factor Authentication Should Be Enforced For The Group](group/two_factor_authentication_not_required_for_group.md)
 2. [Forking of Repositories to External Namespaces Should Be Disabled](group/collaborators_can_fork_repositories_to_external_namespaces.md)


### PR DESCRIPTION
Following some feedback about the fact that the "Server" section creates confusion - we should change the term to the more general "Enterprise" namespace. That's because the policies under this section don't apply just to servers (GHES / GitLab Self-Managed), They also apply for cloud-based SCMs (e.g. [GitHub Enterprise](https://github.com/enterprise)).
Also in this PR: 
- Additional guide targets
- Putting Legitify as the first suggested tool, as it's the only one that covers all of the guide's policies