### PR TITLE
Fix missing binutils version for rpath

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -508,7 +508,7 @@ Table 3: List of discouraged compiler and linker options.
 
 | Compiler Flag                   | Supported since  | Description                                                       |
 |:------------------------------- |:-------------:|:----------------------------------------------------------------- |
-| `-Wl,-rpath,`*`path_to_so`* | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
+| [`-Wl,-rpath,`*`path_to_so`*](#-Wl,-rpath) | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
 
 ---
 
@@ -516,7 +516,7 @@ Table 3: List of discouraged compiler and linker options.
 
 | Compiler Flag                   | Supported since  | Description                                                       |
 |:------------------------------- |:-------------:|:----------------------------------------------------------------- |
-| `-Wl,-rpath,`*`path_to_so`* | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
+| <span id="-Wl,-rpath">`-Wl,-rpath,`*`path_to_so`*</span> | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
 
 #### Synopsis
 

--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -508,7 +508,7 @@ Table 3: List of discouraged compiler and linker options.
 
 | Compiler Flag                   | Supported since  | Description                                                       |
 |:------------------------------- |:-------------:|:----------------------------------------------------------------- |
-| `-Wl,-rpath,`*`path_to_so`*<br/><br/>`-Wl,-rpath,`*`path_to_so`*<br/>`-Wl,--enable-new-dtags` | Binutils | Hard-code run-time search paths in executable files or libraries |
+| `-Wl,-rpath,`*`path_to_so`*<br/><br/>`-Wl,-rpath,`*`path_to_so`*<br/>`-Wl,--enable-new-dtags` | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
 
 ---
 
@@ -516,7 +516,7 @@ Table 3: List of discouraged compiler and linker options.
 
 | Compiler Flag                   | Supported since  | Description                                                       |
 |:------------------------------- |:-------------:|:----------------------------------------------------------------- |
-| `-Wl,-rpath,`*`path_to_so`*<br/><br/>`-Wl,-rpath,`*`path_to_so`*<br/>`-Wl,--enable-new-dtags` | Binutils | Hard-code run-time search paths in executable files or libraries |
+| `-Wl,-rpath,`*`path_to_so`*<br/><br/>`-Wl,-rpath,`*`path_to_so`*<br/>`-Wl,--enable-new-dtags` | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
 
 #### Synopsis
 

--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -508,7 +508,7 @@ Table 3: List of discouraged compiler and linker options.
 
 | Compiler Flag                   | Supported since  | Description                                                       |
 |:------------------------------- |:-------------:|:----------------------------------------------------------------- |
-| `-Wl,-rpath,`*`path_to_so`*<br/><br/>`-Wl,-rpath,`*`path_to_so`*<br/>`-Wl,--enable-new-dtags` | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
+| `-Wl,-rpath,`*`path_to_so`* | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
 
 ---
 
@@ -516,7 +516,7 @@ Table 3: List of discouraged compiler and linker options.
 
 | Compiler Flag                   | Supported since  | Description                                                       |
 |:------------------------------- |:-------------:|:----------------------------------------------------------------- |
-| `-Wl,-rpath,`*`path_to_so`*<br/><br/>`-Wl,-rpath,`*`path_to_so`*<br/>`-Wl,--enable-new-dtags` | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
+| `-Wl,-rpath,`*`path_to_so`* | Binutils 2.11 | Hard-code run-time search paths in executable files or libraries |
 
 #### Synopsis
 


### PR DESCRIPTION
Fixes #164.

Also removes `-Wl,--enable-new-dtags` from list of discouraged options as per @siddhesh's feedback:

> Looking at the _Discouraged Compiler Options_ section a bit closer though, ISTM that the mention of `-Wl,--enable-new-dtags` option is unnecessary. All it does is make the linker generate `DT_RUNPATH` instead of `DT_RPATH` when `-Wl,-rpath` is passed, it doesn't really do anything on its own. Could we just drop it?

Finally, adds an anchor span to the `-Wl,-rpath` description and hyperlink to it from the discouraged options table.
