### PR TITLE
Labs: Put omitted-comma hint at the beginning

### DIFF
--- a/docs/labs/input1.html
+++ b/docs/labs/input1.html
@@ -139,6 +139,10 @@ The following define hints. Hints are expressed in a JSON array, so:
 <div id="hints" style="display:none">
 [
   {
+    "absent": ", $",
+    "text": "This is a parameter, it must end with a comma."
+  },
+  {
     "absent": "query \\( [\"'`]id[\"'`] \\)",
     "text": "Add query(\"id\") to verify its value."
   },
@@ -186,10 +190,6 @@ The following define hints. Hints are expressed in a JSON array, so:
     "present": "max.*min",
     "text":
       "JavaScript allows hash entries to be in any order, but this can be confusing to humans. Conventionally minimum values are given before maximum values; please follow that convention."
-  },
-  {
-    "absent": ", $",
-    "text": "This is a parameter, it must end with a comma."
   }
 ]
 </div>

--- a/docs/labs/input2.html
+++ b/docs/labs/input2.html
@@ -147,6 +147,10 @@ The following define hints. Hints are expressed in a JSON array, so:
 <div id="hints" style="display:none">
 [
   {
+    "absent": ", $",
+    "text": "This is a parameter, it must end with a comma."
+  },
+  {
     "absent": "query \\( [\"'`]id[\"'`] \\)",
     "text": "Use query() with an 'id' parameter."
   },


### PR DESCRIPTION
Put omitted-comma hint at the beginning of the list of hints in labs input1 and input2. It's an easy mistake to make and easier to explain than many other issues. It also serves as a relatively simple pattern to demonstrate how to write hints.