### PR TITLE
Fix tooltips for buttons

### DIFF
--- a/docs/labs/checker.js
+++ b/docs/labs/checker.js
@@ -392,21 +392,21 @@ function initPage() {
     hintButton = document.getElementById('hintButton');
     if (hintButton) {
         hintButton.onclick = (() => showHint());
-        if (hintButton.title == null) {
+        if (!hintButton.title) {
             hintButton.title = 'Provide a hint given current attempt.';
         }
     }
     resetButton = document.getElementById('resetButton');
     if (resetButton) {
         resetButton.onclick = (() => resetForm());
-        if (resetButton.title == null) {
+        if (!resetButton.title) {
             resetButton.title = 'Reset initial state (throwing away current attempt).';
         }
     }
     giveUpButton = document.getElementById('giveUpButton');
     if (giveUpButton) {
         giveUpButton.onclick = (() => showAnswer());
-        if (giveUpButton.title == null) {
+        if (!giveUpButton.title) {
             giveUpButton.title = 'Give up and show an answer.';
         }
     }


### PR DESCRIPTION
If a button doesn't define a title it doesn't necessarily result in the value being "undefined" or "null" - empty string is possible. I find that odd, but it's reality.

This code changes so that if a button title is falsy at all (null, undefined, or empty string), we set its value. That way every button has a tooltip.