### PR TITLE
Show individual statuses as themselves (bugfix)

### DIFF
--- a/docs/labs/checker.js
+++ b/docs/labs/checker.js
@@ -172,7 +172,7 @@ function runCheck() {
         let result = calcOneMatch(attempt, i, correctRe);
         if (!result) isCorrect = false;
         document.getElementById(`attempt${i}`).style.backgroundColor =
-            isCorrect ?  'lightgreen' : 'yellow';
+            result ?  'lightgreen' : 'yellow';
     };
     // isCorrect is now true only if everything matched
     let oldGrade = document.getElementById('grade').innerHTML;


### PR DESCRIPTION
Previously if there were multiple lab entrants, their background color would be set based on cumulative correctness. This was a bug; they should be shown separately.

The only way to notice this is to fill in correct answers in the wrong order, so it's not obvious, but we want to handle this unusual case correctly.