### PR TITLE
Change lab html style to refer to best.openssf.org

### DIFF
--- a/docs/labs/csp1.html
+++ b/docs/labs/csp1.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
+<link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/csp1.html
+++ b/docs/labs/csp1.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/assets/css/style.css">
+<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/hello.html
+++ b/docs/labs/hello.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
+<link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/hello.html
+++ b/docs/labs/hello.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/assets/css/style.css">
+<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/input1.html
+++ b/docs/labs/input1.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/assets/css/style.css">
+<link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/input2.html
+++ b/docs/labs/input2.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
+<link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/input2.html
+++ b/docs/labs/input2.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/assets/css/style.css">
+<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/regex1.html
+++ b/docs/labs/regex1.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
+<link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>

--- a/docs/labs/regex1.html
+++ b/docs/labs/regex1.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/assets/css/style.css">
+<link rel="stylesheet" href=https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>


### PR DESCRIPTION
Modify the lab HTML files to always try to load from best.openssf.org. This is no change for accesses to best.openssf.org, but it means that if you're using the lab locally *and* have internet access, you'll see the same thing. This is an improvement for local testing and individualized use.

Neither approach will allow the use of styles for disconnected operations. That said, the labs will still *work* they'll just look different.