### PR TITLE
Update Compiler-Options-Hardening-Guide-for-C-and-C++.md

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -320,9 +320,9 @@ The C17 standard[^C2017] does not provide a mechanism to mark intentional fallth
 
 ~~~c
 #if __has_attribute(__fallthrough__)
-# define fallthrough                    __attribute__((__fallthrough__))
+# define fallthrough()                    __attribute__((__fallthrough__))
 #else
-# define fallthrough                    do {} while (0)  /* fallthrough */
+# define fallthrough()                    do {} while (0)  /* fallthrough */
 #endif
 ~~~
 


### PR DESCRIPTION
make the fallthrough macro look like a function call

This makes it look like normal code and thus it keeps syntax checkers happy and automatic indentation still works etc.
