### PR TITLE
Implement definitions in checker.js

### DIFF
--- a/docs/labs/create_checker.md
+++ b/docs/labs/create_checker.md
@@ -558,6 +558,40 @@ lab and each different natural language.
 For each button you should set the `title` attribute for the
 given language.
 
+### Advanced use: Definitions
+
+Regular expressions make it easy to describe many patterns.
+However, it's sometimes useful to give certain sequences names, or
+use the same sequence in different circumstances.
+
+Checker allows you to define named terms, and then use them in a regular
+expression.
+This is done in the `definitions` section, which is a sequence
+of a `term` name and its corresponding `value`.
+Any use of the same term in a later definition or a regular expression
+will replaced by its current definition.
+Leading and trailing whitespace in the value is removed.
+
+Here's an example:
+
+~~~~yaml
+definitions:
+- term: RETURN0
+  value: |
+    return \s+ 0 ;
+- term: RETURN0
+  value: |
+    (RETURN0|\{ RETURN0 \})
+~~~~
+
+The first entry defines `RETURN0` as the value `\s+ 0 ;`
+so any future use of RETURN0 will be replaced by that.
+The next entry uses the *same* term name, and declares it to be
+`(RETURN0|\{ RETURN0 \})`.
+The result is that the new value for `RETURN0` will be
+`(\s+ 0 ;|\{ \s+ 0 ; \})` - enabling us to have
+an expression <i>optionally</i> surrounded by curly braces.
+
 ### Advanced use: Select preprocessing commands (e.g., for other languages)
 
 For most programming languages the default regex preprocessing

--- a/docs/labs/oob1.html
+++ b/docs/labs/oob1.html
@@ -28,13 +28,13 @@
 \s*
   if \s+ \(
       (1 \+ 2 \+ 16|19) > s -> s3 -> rrec \. length \)
-  \s+ return \s+ 0 ;
+  \s+ RETURN0
 \s*
 </script>
 <script id="correct1" type="plain/text">
 \s*
   if \s+ \( (1 \+ 2|3) \+ payload \+ 16 > s -> s3 -> rrec \. length \)
-  \s+ return \s+ 0 ;
+  \s+ RETURN0
 \s*
 </script>
 <!--
@@ -57,6 +57,13 @@ hints:
 - absent: |
     \(
   text: Need "(...)" around the condition after an if statement.
+definitions:
+- term: RETURN0
+  value: |
+    return \s+ 0 ;
+- term: RETURN0
+  value: |
+    (RETURN0|\{ RETURN0 \})
 # - present: "import"
 #   text: Yes, many JavaScript implementations support an import statement.
 #     However, in this exercise we will use a require form. Please use that


### PR DESCRIPTION
One problem with regexes is that by default they aren't able to have named definitions like BNF.

Solve this by implementing "definitions". This only adds a few more lines, but now we have a powerful way to create definitions, while still being fast in execution.