### PR TITLE
Adjust description of fallthrough macro to accurately describe guide vs. kernel version

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -320,7 +320,7 @@ This warning flag warns when a fallthrough occurs unless it is specially marked 
 
 This warning flag does not have a performance impact. However, sometimes a fallthrough *is* intentional. This flag requires developers annotate those (rare) cases in the source code where a fallthrough *is* intentional, to suppress the warning. Obviously, this annotation should *only* be used when it is intentional. C++17 (or later) code should simply use the attribute `[[fallthrough]]` as it is standard (remember to add `;` after it).
 
-The C17 standard[^C2017] does not provide a mechanism to mark intentional fallthroughs. Different tools support different mechanisms for marking one, including attributes and comments in various forms[^Shafik15]. A portable way to mark one, used by the Linux kernel version 5.10 and later, is to define a keyword-like macro named `fallthrough` to mark an intentional fallthrough that adjusts to the relevant tool (e.g., compiler) mechanism:
+The C17 standard[^C2017] does not provide a mechanism to mark intentional fallthroughs. Different tools support different mechanisms for marking one, including attributes and comments in various forms[^Shafik15]. A portable way to mark one is to define a function-like macro named `fallthrough()` to mark an intentional fallthrough that adjusts to the relevant tool (e.g., compiler) mechanism:
 
 ~~~c
 #if __has_attribute(__fallthrough__)
@@ -330,6 +330,8 @@ The C17 standard[^C2017] does not provide a mechanism to mark intentional fallth
 #endif
 ~~~
 
+This is similar to the keyword-like macro used by the Linux kernel version 6.4 and later[^Howlett23].
+
 [^Polacek17]: Polacek, Marek, ["-Wimplicit-fallthrough in GCC 7"](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7), Red Hat Developer, 2017-03-10
 
 [^Corbet19]: Corbet, Jonathan.  ["An end to implicit fall-throughs in the kernel"](https://lwn.net/Articles/794944/), LWN, 2019-08-01.
@@ -337,6 +339,8 @@ The C17 standard[^C2017] does not provide a mechanism to mark intentional fallth
 [^C2017]: ISO/IEC, [Programming languages — C ("C17")](https://web.archive.org/web/20181230041359/http://www.open-std.org/jtc1/sc22/wg14/www/abq/c17_updated_proposed_fdis.pdf), ISO/IEC 9899:2018, 2017. Note: The official ISO/IEC specification is paywalled and therefore not publicly available. The final specification draft is publicly available.
 
 [^Shafik15]: Shafik, Yaghmour, ["GCC 7, -Wimplicit-fallthrough warnings, and portable way to clear them?"](https://stackoverflow.com/questions/27965722/c-force-compile-time-error-warning-on-implicit-fall-through-in-switch/27965827#27965827), StackOverflow, 2015-01-15.
+
+[^Howlett23]: Howlett, Liam,[tools: Rename __fallthrough to fallthrough](https://github.com/torvalds/linux/commit/f7a858bffcddaaf70c71b6b656e7cc21b6107cec), Linux Kernel Source, 2023-04-07.
 
 ---
 


### PR DESCRIPTION
Adjust description of `fallthrough()` macro to accurately describe guide vs. kernel version after change in #469.

Brought up during discussion in [C/C++ Compiler BP Guide call 2024-05-02](https://docs.google.com/document/d/1JY8FREBPCUUFpuv7-4B9EjeS2MLDpel0dbG5DFWrTns/edit#bookmark=id.90vj0g5nxihp).