### PR TITLE
Fixes #519: code examples use Jekyll

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/CWE-664/CWE-400/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-664/CWE-400/README.md
@@ -8,39 +8,8 @@ Tasks can be submitted to the ThreadPoolExecutor by calling `submit()`. Submitte
 
 [*noncompliant01.py:*](noncompliant01.py)
 
-```py
-""" Non-compliant Code Example """
-import time
-from concurrent.futures import ThreadPoolExecutor
-
-
-def take_time(x):
-    print(f"Started Task: {x}")
-    # Simulate work
-    for i in range(10):
-        time.sleep(1)
-    print(f"Completed Task: {x}")
-
-
-def run_thread(_executor, var):
-    future = _executor.submit(take_time, var)
-    return future
-
-
-def interrupt(future):
-    print(future.cancel())
-    print(f"Interrupted: {future}")
-
-
-#####################
-# Exploiting above code example
-#####################
-
-
-with ThreadPoolExecutor() as executor:
-    task = run_thread(executor, "A")
-    interrupt(task)
-
+```python
+{% include_relative noncompliant01.py %}
 ```
 
 ## Compliant Solution
@@ -49,46 +18,8 @@ Tasks submitted to the ThreadPoolExecutor can be interrupted by setting a thread
 
 [*compliant01.py:*](compliant01.py)
 
-```py
-""" Compliant Code Example """
-import time
-from concurrent.futures import ThreadPoolExecutor
-from threading import Event
-
-
-def take_time(x, _event):
-    print(f"Started Task: {x}")
-    # Simulate work
-    for _ in range(10):
-        if _event.is_set():
-            print(f"Interrupted Task: {x}")
-            # Save partial results
-            return
-        time.sleep(1)
-    print(f"Completed Task: {x}")
-
-
-def run_thread(_executor, var):
-    e = Event()
-    future = _executor.submit(take_time, var, e)
-    return future, e
-
-
-def interrupt(future, e):
-    """Cancel the task, just in case it is not yet running, and set the Event flag"""
-    future.cancel()
-    e.set()
-
-
-#####################
-# Exploiting above code example
-#####################
-
-
-with ThreadPoolExecutor() as executor:
-    task, event = run_thread(executor, "A")
-    interrupt(task, event)
-
+```python
+{% include_relative compliant01.py %}
 ```
 
 ## Related Guidelines

--- a/docs/Secure-Coding-Guide-for-Python/CWE-664/CWE-410/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-664/CWE-410/README.md
@@ -14,55 +14,8 @@ The `noncompliant01.py` code example demonstrates the Thread-Per-Message design 
 
 *[noncompliant01.py](noncompliant01.py):*
 
-```py
-""" Non-compliant Code Example """
-import logging
-import threading
-import time
-
-logging.basicConfig(level=logging.INFO)
-
-
-def process_message(message: str, processed_messages: list):
-    """ Method simulating mediation layer i/o heavy work"""
-    logging.debug("process_message: started message   %s working %is", message, int(message) / 10)
-    for _ in range(int(message)):
-        time.sleep(0.01)
-    logging.debug("process_message: completed message %s", message)
-    processed_messages.append(f"processed {message}")
-
-
-class MessageAPI(object):
-    """Class simulating the front end facing API"""
-
-    def add_messages(self, messages: list) -> list:
-        """ Receives a list of messages to work on """
-        logging.info("add_messages: got %i messages to process", len(messages))
-        processed_messages = []
-        threads = []
-        for message in messages:
-            threads.append(
-                threading.Thread(target=process_message, args=[message, processed_messages]))
-            threads[-1].start()
-        logging.debug("add_messages: submitted %i messages", len(messages))
-        for thread in threads:
-            thread.join()
-        logging.info("add_messages: messages_done=%i", len(processed_messages))
-        return processed_messages
-
-
-#####################
-# exploiting above code example
-#####################
-mapi = MessageAPI()
-attacker_messages = [str(msg) for msg in range(1000)]
-print("ATTACKER: start sending messages")
-result_list = mapi.add_messages(attacker_messages)
-print(
-    f"ATTACKER: done sending {len(attacker_messages)} messages, got {len(result_list)} messages "
-    f"back")
-print(f"ATTACKER: result_list = {result_list}")
-
+```python
+{% include_relative noncompliant01.py %}
 ```
 
 The `noncompliant01.py` code creates a risk of having a single component exhaust all available hardware resources even when used by a single user for a single use-case. When running the code, the Unix `top` command can show a significant increase in CPU usage (%CPU exceeds 100% because multiple cores are being used):
@@ -80,64 +33,8 @@ The attacker could still flood the server by creating multiple MessageAPI, each 
 
 *[compliant01.py](compliant01.py)*
 
-```py
-""" Compliant Code Example """
-import logging
-import time
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait
-
-logging.basicConfig(level=logging.INFO)
-
-
-def process_message(message: str):
-    """ Method simulating mediation layer i/o heavy work"""
-    logging.debug("process_message: started message   %s working %is", message, int(message) / 10)
-    for _ in range(int(message)):
-        time.sleep(0.01)
-    logging.debug("process_message: completed message %s", message)
-    return f"processed {message}"
-
-
-class MessageAPI(object):
-    """Class simulating the front end facing API"""
-    # TODO: Prevent the attacker from creating multiple MessageAPI objects
-
-    def __init__(self):
-        # TODO: set or handle timeout as it is provided by the mediation layer
-        self.timeout = 1
-        self.executor = ThreadPoolExecutor()
-
-    def add_messages(self, messages: list) -> list:
-        """ Receives a list of messages to work on """
-        # TODO: limit on max messages from the mediation layer.
-        # TODO: input sanitation.
-        futures = []
-        # with self.executor:
-        for message in messages:
-            futures.append(self.executor.submit(process_message, message))
-        logging.debug("add_messages: submitted %i messages, waiting for %is to complete.", len(messages), self.timeout)
-        messages_done, messages_not_done = wait(futures, timeout=self.timeout)
-        for future in messages_not_done:
-            future.cancel()
-
-        logging.info("add_messages: messages_done=%i messages_not_done=%i", len(messages_done), len(messages_not_done))
-        process_messages = []
-        for future in messages_done:
-            process_messages.append(future.result())
-        return process_messages
-
-
-#####################
-# exploiting above code example
-#####################
-mapi = MessageAPI()
-result_list = []
-attacker_messages = [str(msg) for msg in range(100)]
-print("ATTACKER: start sending messages")
-result_list = mapi.add_messages(attacker_messages)
-print(f"ATTACKER: done sending {len(attacker_messages)} messages, got {len(result_list)} messages back")
-print(f"ATTACKER: result_list = {result_list}")
+```python
+{% include_relative compliant01.py %}
 ```
 
 Now, after the timeout is reached, `MessageAPI` drops unprocessed messages and returns partial results:
@@ -155,63 +52,8 @@ The `executor.shutdown()`  method has a `cancel_futures` parameter, which by def
 
 *[noncompliant02.py](noncompliant02.py):*
 
-```py
-""" Non-compliant Code Example """
-import logging
-import time
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait
-
-logging.basicConfig(level=logging.INFO)
-
-
-def process_message(message: str):
-    """ Method simulating mediation layer i/o heavy work"""
-    logging.debug("process_message: started message   %s working %is", message, int(message) / 10)
-    for _ in range(int(message)):
-        time.sleep(0.01)
-    logging.debug("process_message: completed message %s", message)
-    return f"processed {message}"
-
-
-class MessageAPI(object):
-    """Class simulating the front end facing API"""
-
-    def __init__(self):
-        self.executor = ThreadPoolExecutor()
-        self.timeout = 1
-
-    def add_messages(self, messages: list) -> list:
-        """ Receives a list of messages to work on """
-        futures = []
-        for message in messages:
-            futures.append(self.executor.submit(process_message, message))
-
-        logging.debug("add_messages: submitted %i messages, waiting for %is to complete.",
-                      len(messages), self.timeout)
-        messages_done, messages_not_done = wait(futures, timeout=self.timeout)
-
-        logging.info("add_messages: messages_done=%i messages_not_done=%i", len(messages_done),
-                     len(messages_not_done))
-
-        process_messages = []
-        for future in messages_done:
-            process_messages.append(future.result())
-        return process_messages
-
-
-#####################
-# exploiting above code example
-#####################
-mapi = MessageAPI()
-result_list = []
-attacker_messages = [str(msg) for msg in range(1000)]
-print("ATTACKER: start sending messages")
-result_list = mapi.add_messages(attacker_messages)
-print(
-    f"ATTACKER: done sending {len(attacker_messages)} messages, got {len(result_list)} messages "
-    f"back")
-print(f"ATTACKER: result_list = {result_list}")
+```python
+{% include_relative noncompliant02.py %}
 ```
 
 ## Compliant Solution (Thread Pool with grace period)
@@ -220,77 +62,8 @@ The `compliant01.py` can be expanded by adding a grace period. Before dropping t
 
 *[compliant02.py](compliant02.py):*
 
-```py
-""" Compliant Code Example """
-import logging
-import time
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait
-
-logging.basicConfig(level=logging.INFO)
-
-
-def process_message(message: str):
-    """ Method simulating mediation layer i/o heavy work"""
-    logging.debug("process_message: started message   %s working %is", message, int(message) / 10)
-    for _ in range(int(message)):
-        time.sleep(0.01)
-    logging.debug("process_message: completed message %s", message)
-    return f"processed {message}"
-
-
-class MessageAPI(object):
-    """Class simulating the front end facing API"""
-    # TODO: Prevent the attacker from creating multiple MessageAPI objects
-
-    def __init__(self):
-        # TODO: set or handle timeout as it is provided by the mediation layer
-        self.timeout = 1
-        self.executor = ThreadPoolExecutor()
-
-    def add_messages(self, messages: list) -> list:
-        """ Receives a list of messages to work on """
-        # TODO: limit on max messages from the mediation layer.
-        # TODO: input sanitation.
-        futures = []
-        # with self.executor:
-        for message in messages:
-            futures.append(self.executor.submit(process_message, message))
-        logging.debug("add_messages: submitted %i messages, waiting for %is to complete.",
-                      len(messages), self.timeout)
-        messages_done, messages_not_done = wait(futures, timeout=self.timeout)
-        logging.info("add_messages: messages_done=%i messages_not_done=%i", len(messages_done),
-                     len(messages_not_done))
-        if len(messages_not_done) > 0:
-            # TODO: be graceful, warn a trusted client
-            logging.warning("add_messages: %i messages taking longer than %is, %i more to process",
-                            len(messages), self.timeout, len(messages_not_done))
-            messages_done, messages_not_done = wait(futures, timeout=self.timeout)
-            logging.info("add_messages: messages_done=%i messages_not_done=%i", len(messages_done),
-                         len(messages_not_done))
-        for future in messages_not_done:
-            future.cancel()
-
-        logging.info("add_messages: messages_done=%i messages_not_done=%i", len(messages_done),
-                     len(messages_not_done))
-        process_messages = []
-        for future in messages_done:
-            process_messages.append(future.result())
-        return process_messages
-
-
-#####################
-# exploiting above code example
-#####################
-mapi = MessageAPI()
-result_list = []
-attacker_messages = [str(msg) for msg in range(100)]
-print("ATTACKER: start sending messages")
-result_list = mapi.add_messages(attacker_messages)
-print(
-    f"ATTACKER: done sending {len(attacker_messages)} messages, got {len(result_list)} messages "
-    f"back")
-print(f"ATTACKER: result_list = {result_list}")
+```python
+{% include_relative compliant02.py %}
 ```
 
 ## Automated Detection

--- a/docs/Secure-Coding-Guide-for-Python/CWE-664/CWE-833/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-664/CWE-833/README.md
@@ -8,48 +8,8 @@ The `noncompliant01.py` code example shows how a thread-starvation deadlock coul
 
 *[noncompliant01.py](noncompliant01.py):*
 
-```py
-""" Non-compliant Code Example """
-
-from concurrent.futures import ThreadPoolExecutor
-from typing import List
-
-
-class ReportTableGenerator(object):
-    def __init__(self):
-        self.executor = ThreadPoolExecutor()
-
-    def generate_string_table(self, inputs: List[str]) -> str:
-        futures = []
-        aggregated = "|Data|Length|\n"
-        for i in inputs:
-            futures.append(self.executor.submit(self._create_table_row, i))
-        for future in futures:
-            aggregated += future.result()
-        return aggregated
-
-    def _create_table_row(self, row: str) -> str:
-        print(f"Creating a row out of: {row}")
-        future = self.executor.submit(self._reformat_string, row)
-        return f"|{future.result()}|{len(row)}|\n"
-
-    def _reformat_string(self, row: str) -> str:
-        print(f"Reformatting {row}")
-        row_reformated = row.capitalize()
-        return row_reformated
-
-
-#####################
-# exploiting above code example
-#####################
-report_table_generator = ReportTableGenerator()
-attacker_messages = [str(msg) for msg in range(1000)]
-print("ATTACKER: start sending messages")
-result = report_table_generator.generate_string_table(attacker_messages)
-print(
-    f"ATTACKER: done sending {len(attacker_messages)} messages, got {len(result)} messages "
-    f"back")
-print(f"ATTACKER: result = {result}")
+```python
+{% include_relative noncompliant01.py %}
 ```
 
 The problem arises when the number of concurrently built rows exceeds the number of `_max_workers`. In this example, each worker thread could be occupied with the execution of the `_create_table_row()` method, while the tasks of `executing _reformat_string()` are waiting in the queue. Since the `_create_table_row()` method spawns a `_reformat_string()` thread and waits for its result, every worker will wait for another worker to finish their part of the row-building process. Because all workers are busy with the `_create_table_row()` task, no worker will be able to take the string reformatting out of the queue, causing a deadlock.
@@ -60,47 +20,8 @@ The `compliant01.py` code example illustrates how interdependent tasks could be 
 
 *[compliant01.py](compliant01.py):*
 
-```py
-""" Compliant Code Example """
-
-from concurrent.futures import ThreadPoolExecutor
-from typing import List
-
-
-class ReportTableGenerator(object):
-    def __init__(self):
-        self.executor = ThreadPoolExecutor()
-
-    def generate_string_table(self, inputs: List[str]) -> str:
-        futures = []
-        aggregated = "|Data|Length|\n"
-        for i in inputs:
-            futures.append(self.executor.submit(self._create_table_row, i))
-        for future in futures:
-            aggregated += future.result()
-        return aggregated
-
-    def _create_table_row(self, row: str) -> str:
-        print(f"Creating a row out of: {row}")
-        return f"|{self._reformat_string(row)}|{len(row)}|\n"
-
-    def _reformat_string(self, row: str) -> str:
-        print(f"Reformatting {row}")
-        row_reformated = row.capitalize()
-        return row_reformated
-
-
-#####################
-# exploiting above code example
-#####################
-report_table_generator = ReportTableGenerator()
-attacker_messages = [str(msg) for msg in range(1000)]
-print("ATTACKER: start sending messages")
-result = report_table_generator.generate_string_table(attacker_messages)
-print(
-    f"ATTACKER: done sending {len(attacker_messages)} messages, got {len(result)} messages "
-    f"back")
-print(f"ATTACKER: result = {result}")
+```python
+{% include_relative compliant01.py %}
 ```
 
 Now, the `_create_table_row()` method is executed in a separate thread but does not spawn any more threads, instead reformatting the string sequentially. Because each input argument can have its row built separately, no thread will need to wait for another to finish, which avoids thread-starvation deadlocks.
@@ -112,50 +33,8 @@ The BankingService class allows to concurrently validate the cards of all of the
 
 *[noncompliant02.py](noncompliant02.py):*
 
-```py
-""" Non-compliant Code Example """
-
-from concurrent.futures import ThreadPoolExecutor, wait
-from threading import Lock
-from typing import Callable
-
-
-class BankingService(object):
-    def __init__(self, n: int):
-        self.executor = ThreadPoolExecutor()
-        self.number_of_times = n
-        self.count = 0
-        self.lock = Lock()
-
-    def for_each_client(self):
-        print("For each client")
-        self.invoke_method(self.for_each_account)
-
-    def for_each_account(self):
-        print("For each account")
-        self.invoke_method(self.for_each_card)
-
-    def for_each_card(self):
-        print("For each card")
-        self.invoke_method(self.check_card_validity)
-
-    def check_card_validity(self):
-        with self.lock:
-            self.count += 1
-            print(f"Number of checked cards: {self.count}")
-
-    def invoke_method(self, method: Callable):
-        futures = []
-        for _ in range(self.number_of_times):
-            futures.append(self.executor.submit(method))
-        wait(futures)
-
-
-#####################
-# exploiting above code example
-#####################
-browser_manager = BankingService(5)
-browser_manager.for_each_client()
+```python
+{% include_relative noncompliant02.py %}
 ```
 
 For the sake of the example, let's assume we have 5 clients, with 5 accounts and 5 cards for each account `number_of_times = 5`. In that case, we end up calling `check_card_validity() 125` times, exhausting `_max_workers` which is typically at around `32`. [Source: Python Docs] You can additionally call `self.executor._work_queue.qsize()` to get the exact number of tasks that are waiting in the queue, unable to be executed by the already busy workers.
@@ -166,69 +45,8 @@ Python, as opposed to Java, does not provide `CallerRunsPolicy`, which was sugge
 
 *[compliant02.py](compliant02.py):*
 
-```py
-""" Compliant Code Example """
-
-from concurrent.futures import ThreadPoolExecutor, wait
-from threading import Lock
-from typing import Callable
-
-
-class BankingService(object):
-    def __init__(self, n: int):
-        self.executor = ThreadPoolExecutor()
-        self.number_of_times = n
-        self.count = 0
-        self.all_tasks = []
-        self.lock = Lock()
-
-    def for_each_client(self):
-        print("Per client")
-        self.invoke_method(self.for_each_account)
-
-    def for_each_account(self):
-        print("Per account")
-        self.invoke_method(self.for_each_card)
-
-    def for_each_card(self):
-        print("Per card")
-        self.invoke_method(self.check_card_validity)
-
-    def check_card_validity(self):
-        with self.lock:
-            self.count += 1
-            print(f"Number of checked cards: {self.count}")
-
-    def invoke_method(self, method: Callable):
-        futures = []
-        for _ in range(self.number_of_times):
-            if self.can_fit_in_executor():
-                self.lock.acquire()
-                future = self.executor.submit(method)
-                self.all_tasks.append(future)
-                self.lock.release()
-                futures.append(future)
-            else:
-                # Execute the method in the thread that invokes it
-                method()
-        wait(futures)
-
-    def can_fit_in_executor(self):
-        running = 0
-        for future in self.all_tasks:
-            if future.running():
-                running += 1
-        print(f"Max workers: {self.executor._max_workers}, Used workers:  {running}")
-        # Depending on the order of submitted subtasks, the script can sometimes deadlock
-        # if we don't leave a spare worker.
-        return self.executor._max_workers > running + 1
-
-
-#####################
-# exploiting above code example
-#####################
-browser_manager = BankingService(5)
-browser_manager.for_each_client()
+```python
+{% include_relative compliant02.py %}
 ```
 
 This compliant code example adds a list of all submitted tasks to the `BankingService` class. The lock, apart from controlling the counter, now ensures that only one thread can access the `all_tasks` list at a time. Before a new task is submitted, `can_fit_in_executor()` checks if submitting a new task will exhaust the thread pool. If so, the task is executed in the thread that tried to submit it.

--- a/docs/Secure-Coding-Guide-for-Python/CWE-682/CWE-1335/01/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-682/CWE-1335/01/README.md
@@ -11,19 +11,8 @@ The `example01.py` code demonstrates bit-wise operators available in Python.
 
 *[example01.py](example01.py):*
 
-```py
-foo = 50
-bar = 42
-print(f"foo = {foo} = {foo:08b}") # :08b is just for pretty print
-print(f"foo = {bar} = {bar:08b}\n")
-
-# bit wise operations in Python:
-print(f"foo << 2 = {(foo << 2):08b}")   # binary shift left
-print(f"foo >> 2 = {(foo >> 2):08b}")   # binary shift right
-print(f"~foo     = {(~foo):08b}")       # flipping bits
-print(f"foo & bar  = {(foo & bar):08b}")    # binary AND
-print(f"foo | bar  = {(foo | bar):08b}")    # binary OR
-print(f"foo ^ bar  = {(foo ^ bar):08b}")    # binary XOR
+```python
+{% include_relative example01.py %}
 ```
 
 Output from above example01.py:
@@ -31,7 +20,7 @@ Output from above example01.py:
 ```bash
 foo = 50 = 00110010
 foo = 42 = 00101010
- 
+
 foo << 2 = 11001000
 foo >> 2 = 00001100
 ~foo     = -0110011
@@ -44,10 +33,8 @@ The `example02.py` code demonstrates how Python 2 changes an int to long to prev
 
 *[example02.py](example02.py):*
 
-```py
-for shift in [16, 32, 64]:
-    bar = 5225 << shift
-    print("foo << " + str(shift) + ": type " + str(type(bar)) + " " + str(bin(bar)))
+```python
+{% include_relative example02.py %}
 ```
 
 Left shift in `example02.py` changes type to long class in Python 2:
@@ -72,10 +59,8 @@ Multiplication by `4` can be archived by a `2x` left. The `noncompliant01.py` co
 
 *[noncompliant01.py](noncompliant01.py):*
 
-```py
-""" Non-compliant Code Example """
-
-print(8 << 2 + 10)
+```python
+{% include_relative noncompliant01.py %}
 ```
 
 The `noncompliaint01.py` code results in printing `32768` instead of `42`. Adding brackets `print((8 << 2) + 10)` would fix this specific issue whilst still remaining prune to other issues.
@@ -86,10 +71,8 @@ The statement in `compliant01.py` clarifies the programmer's intention.
 
 *[compliant01.py](compliant01.py):*
 
-```py
-""" Compliant Code Example """
-
-print(8 * 4 + 10)
+```python
+{% include_relative compliant01.py %}
 ```
 
 It is recommended by *[CWE-191, Integer Underflow (Wrap or Wraparound)](../CWE-191/README.md)* to also check for under or overflow.
@@ -100,13 +83,8 @@ In this non-compliant code example is using an arithmetic right shift >>= operat
 
 *[noncompliant02.py](noncompliant02.py):*
 
-```py
-""" Non-compliant Code Example """
-
-foo: int
-foo = -50
-foo >>= 2
-print(foo)
+```python
+{% include_relative noncompliant02.py %}
 ```
 
 The expectation of the `>>= 2` right shift operator is that it fills the leftmost bits of `0011 0010` with two zeros resulting in `0000 1100` or decimal twelve. Instead a potentially expected `-12` in `foo` we have internal processing truncating the values from `-12.5` to `-13`.
@@ -117,13 +95,8 @@ The right shift is replaced by division in `compliant02.py`.
 
 *[compliant02.py](compliant02.py):*
 
-```py
-""" Compliant Code Example """
-
-foo: int
-foo = -50
-foo /= 4
-print(foo)
+```python
+{% include_relative compliant02.py %}
 ```
 
 ## Automated Detection


### PR DESCRIPTION
### Fix for Issue #519: Python guide: include code examples using Jekyll

#### Description
Replace duplicated python example code in each existing README.md doc with Jekyll include_relative tag.

Replace '```py' with '```python' as the recommended language identifier for python code blocks.

#### References
- Fixes #519