### PR TITLE
Refer to 'RIP-relative addressing' in position-independent code description

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -828,7 +828,7 @@ Negligible on 64-bit architectures.
 
 On 32-bit x86 PIC exhibits moderate performance penalties (5-10%)[^ubuntu-hardening]. This is due to data accesses using mov instructions on 32-bit x86 only support absolute addresses. To make the code position-independent memory references are transformed to lookup memory addresses from a global offset table (GOT) populated at load-time with the correct addresses to program data. Consequently, data references require an additional memory load compared to non-PIC code on 32-bit x86. However, the main reason for the performance penalty is the increased register pressure resulting from keeping the lookup address to the GOT available in a register[^Bendersky11a].
 
-The x86_64 architecture supports mov instructions that address memory using offsets relative to the instruction pointer (i.e., the address of the currently executing instruction). This is referred to as RIP addressing. PIC on x86_64 uses RIP addressing for accessing the GOT which relieves the register pressure associated with PIC on 32-bit x86 and results in a smaller impact on performance. Shared libraries are created PIC on x86_64 by default[^Bendersky11b].
+The x86_64 architecture supports a variant of mov and certain other instructions that address memory using offsets relative to the instruction pointer (i.e., the address of the currently executing instruction). This is referred to as RIP-relative addressing. PIC on x86_64 uses RIP-relative addressing for accessing the GOT which relieves the register pressure associated with PIC on 32-bit x86 and results in a smaller impact on performance. Shared libraries are created PIC on x86_64 by default[^Bendersky11b].
 
 #### When not to use?
 


### PR DESCRIPTION
- Clarify RIP-relative addressing is available for certain other instructions other than mov as well