### PR TITLE
Fix shell-injection lab by adding missing <form>

### DIFF
--- a/docs/labs/shell-injection.html
+++ b/docs/labs/shell-injection.html
@@ -134,6 +134,7 @@ we'll do that to keep the example simple.
 <p>
 Rewrite the following function to be safe:
 <p>
+<form id="lab">
 <pre><code>def list_directory(dir_to_list):
   # Modify the directory so it only contains a-zA-Z0-9
 <textarea id="attempt0" rows="2" cols="60" spellcheck="false">


### PR DESCRIPTION
Somehow the `<form>` element got dropped, causing the lab to stop working. This fixes it.