### PR TITLE
Add link to additional source code platform management configuration guidance focused on collaboration

### DIFF
--- a/docs/SCM-BestPractices/README.md
+++ b/docs/SCM-BestPractices/README.md
@@ -4,7 +4,7 @@ _by the [Open Source Security Foundation (OpenSSF)](https://openssf.org) [Best P
 
 ## Intro
 
-Collaborative source code management platforms (such as GitHub and GitLab) play a critical role in modern software development, providing a central repository for storing, managing, and versioning source code as well as collaborating with a community of developers. However, they also represent a potential security risk if not properly configured. In this guide, we will explore the best practices for securing these platforms, covering topics that include user authentication, access control, permissions, monitoring, and logging.
+Collaborative source code management platforms (such as GitHub and GitLab) play a critical role in modern software development, providing a central repository for storing, managing, and versioning source code as well as collaborating with a community of developers. However, they also represent a potential security risk if not properly configured. In this guide, we will explore the best practices for securing these platforms, covering topics that include user authentication, access control, permissions, monitoring, and logging. For additional guidance on selecting configurations that enable cross-organization collaboration, consider the InnerSource Commmon's [guidance section on InnerSource strategy for source code management platform configuration](https://innersourcecommons.gitbook.io/managing-innersource-projects/innersource-tooling). 
 
 ## Audience
 


### PR DESCRIPTION
Add link to additional source code platform management configuration guidance focused on collaboration by InnerSource Commons (non-profit) 

This was previously discussed in working group video call and https://github.com/ossf/wg-best-practices-os-developers/issues/557 