### PR TITLE
Clarify the interaction between trampolines and `-Wl,-z,noexecstack`

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -297,11 +297,15 @@ For C++ warnings about conversions between signed and unsigned integers are disa
 
 #### Synopsis
 
-Check whether the compiler generates trampolines for pointers to nested functions which may interfere with stack virtual memory protection (non-executable stack.)
+Check whether the compiler generates trampolines for pointers to nested functions[^gnuc-nestedfuncs] (a GNU C extension to ISO standard C) which stack virtual memory protection (non-executable stack) may interfere with.
 
 A trampoline is a small piece of data or code that is created at run time on the stack when the address of a nested function is taken and is used to call the nested function indirectly.
 
-For most target architectures, including 64-bit x86, trampolines are made up of code and thus requires the stack to be made executable for the program to work properly. This interferes with the non-executable stack mitigation which is used by all major operating system to prevent code injection attacks (see Section 2.10).
+For most target architectures, including 64-bit x86, trampolines are made up of code and thus requires the stack to be made executable for the program to work properly. The non-executable stack mitigation (see [`-Wl,-z,noexecstack`](#-Wl,-z,noexecstack)) used by all major operating system to prevent code injection attacks may interfere with the operation such trampolines causing a non-compatible programs to crash when they transfer control flow to a trampoline on a non-executable stack.
+
+Enabling `-Wtrampolines` warns of programming constructs which are not compatible with the non-executable stack mitigation.
+
+[^gnuc-nestedfuncs]: Stallman, Richard, [Nested Functions](https://www.gnu.org/software/c-intro-and-ref/manual/html_node/Nested-Functions.html), GNU C Language Introduction and Reference Manual, 2023-10-15.
 
 ---
 
@@ -775,9 +779,9 @@ None, marking the stack and/or heap as non-executable does not have an impact on
 
 #### When not to use?
 
-Some language-level programming constructs, such as taking the address of a nested function (a GNU C extension to ISO standard C) requires special compiler handling which may prevent the linker from marking stack segments correctly as non-executable[^gcc-trampolines].
+Some language-level programming constructs, such as taking the address of a nested function[^gnuc-nestedfuncs] (a GNU C extension to ISO standard C) requires special compiler handling which may not work correctly if the linker mark stack segments as non-executable[^gcc-trampolines].
 
-Consequently the `-Wl,-z,noexecstack` option works best when combined with appropriate warning flags (`-Wtrampolines` where available) that indicate whether language constructs interfere with stack virtual memory protection.
+Consequently the `-Wl,-z,noexecstack` option works best when combined with appropriate warning flags ([`-Wtrampolines`](#-Wtrampolines) where available) that indicate whether stack virtual memory protection interferes with language constructs.
 
 [^gcc-trampolines]: GCC team, [Support for Nested Functions.](https://gcc.gnu.org/onlinedocs/gccint/Trampolines.html), GCC Internals, 2023-07-27.
 

--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -783,7 +783,17 @@ Some language-level programming constructs, such as taking the address of a nest
 
 Consequently the `-Wl,-z,noexecstack` option works best when combined with appropriate warning flags ([`-Wtrampolines`](#-Wtrampolines) where available) that indicate whether stack virtual memory protection interferes with language constructs.
 
+#### Additional Considerations
+
+Modern compilers perform this marking automatically through the `p_flags` field in the `PT_GNU_STACK` program header entry and the linker consults the entries for consituent objects when deciding the marking for the produced binary. If the marking is missing the kernel or the dynamic linker needs to assume the binary might need executable stack.
+
+In Linux prior to kernel version 5.8 a missing `PT_GNU_STACK` marking on x86_64 will also expose other readable pages (such as the program `.data` section) as executable[^Hernandez2013], not just their stack memory. While this behavior has since changed[^Cook2020], we recommend enabling `-Wl,-z,noexecstack` explicitly during linking to ensure produced binaries benefit from data execution prevention for both the stack and other program data as widely as possible and guarding against compatibility issues by using the [`-Wtrampolines`](#-Wtrampolines) in tandem when available.
+
 [^gcc-trampolines]: GCC team, [Support for Nested Functions.](https://gcc.gnu.org/onlinedocs/gccint/Trampolines.html), GCC Internals, 2023-07-27.
+
+[^Hernandez2013]: Hernandez, Alejandro, [A Short Tale About executable_stack in elf_read_implies_exec() in the Linux Kernel](https://ioactive.com/a-short-tale-about-executable_stack-in-elf_read_implies_exec-in-the-linux-kernel/), IOActive, 2013-11-27.
+
+[^Cook2020]: Cook, Kees, [x86/elf: Disable automatic READ_IMPLIES_EXEC on 64-bit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9fccc5c0c99f238aa1b0460fccbdb30a887e7036), Linux Kernel Source, 2020-03-26.
 
 ---
 


### PR DESCRIPTION
Clarify the description of `-Wtrampolines` and `-Wl,-z,noexecstack` to make it clear code that requires trampolines on the stack will crash with the `-Wl,-z,noexecstack` mitigation and how the usage of `-Wtrampolines` warns of such occurences.

Also adds an additional considerations for -Wl,-z,noexecstack covering:
- how modern compilers determine the noexecstack markings automatically, but missing markings result in the stack being mapped executable
- how Linux versions prior to 5.8 also expose other program data executable if the stack is not mapped as non-executable