### PR TITLE
Unassign labs for hardcoded credentials and XSS

### DIFF
--- a/docs/labs/README.md
+++ b/docs/labs/README.md
@@ -89,7 +89,7 @@ work on.
 * Processing Data Securely
   * Processing Data Securely: General Issues
     * [Prefer Trusted Data. Treat Untrusted Data as Dangerous](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#prefer-trusted-data-treat-untrusted-data-as-dangerous) - PLANNED-2 UNASSIGNED
-    * [Avoid Default & Hardcoded Credentials](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#avoid-default--hardcoded-credentials) - PLANNED-1 <!-- Was @J Howard, 2024-08-13 --> ([Josetic224 SophiaUgo](https://github.com/cncf/tag-security/issues/1335))
+    * [Avoid Default & Hardcoded Credentials](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#avoid-default--hardcoded-credentials) - PLANNED-1 UNASSIGNED
     * [Avoid Incorrect Conversion or Cast](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#avoid-incorrect-conversion-or-cast) - DONE-2 (Keith Grant via Vincent Danen, by 2024-07-26) [conversion](conversion.html)
   * Processing Data Securely: Undefined Behavior / Memory Safety
     * Countering Out-of-Bounds Reads and Writes (Buffer Overflow) - DONE-0 [oob1](oob1.html)
@@ -113,7 +113,7 @@ work on.
     * Countering Denial-of-Service (DoS) Attacks - PLANNED-2 UNASSIGNED
 * Sending Output
   * [Introduction to Sending Output](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#introduction-to-sending-output) - PLANNED-2 UNASSIGNED
-  * [Countering Cross-Site Scripting (XSS)](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#countering-cross-site-scripting-xss) - PLANNED-1 <!-- Was @Emily Lovell, 2024-08-13 --> [Josetic224 SophiaUgo](https://github.com/cncf/tag-security/issues/1335)
+  * [Countering Cross-Site Scripting (XSS)](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#countering-cross-site-scripting-xss) - PLANNED-1 UNASSIGNED
   * Content Security Policy (CSP) - DONE-0 [csp1](csp1.html)
   * Other HTTP Hardening Headers - (probably continue csp1) PLANNED-2 UNASSIGNED
   * [Cookies Cookies & Login Sessions Login Sessions](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md#cookies--login-sessions) - PLANNED-2 (Dhananjay Arunesh via Vincent Danen)


### PR DESCRIPTION
These tier-1 labs had been assigned, but I haven't heard from the assignees for over a month, even after repeated requests. So I'm unassigning these specific labs.

I presume that other tasks have (unfortunately) had to take priority. That happens. It's possible they had a more serious problem, e.g., a medical issue; if so, we hope they're okay!

I hope they'll be able to rejoin this effort at some future time.