### PR TITLE
pySCG: template for contributing to the project

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/contribution/README_TEMPLATE.md
+++ b/docs/Secure-Coding-Guide-for-Python/contribution/README_TEMPLATE.md
@@ -1,0 +1,78 @@
+# CWE-000: Title goes here
+
+Introduction paragraph...
+
+[*example01.py:*](example01.py)
+
+```py
+""" Code Example """
+
+# Code goes here
+```
+
+ **Output of example01.py:**
+
+```bash
+Console output...
+```
+
+## Non-Compliant Code Example
+
+Introduction to the code example...
+
+*[noncompliant01.py](noncompliant01.py):*
+
+```python
+""" Non-compliant Code Example """
+
+# Code goes here
+
+#####################
+# Exploiting above code example
+#####################
+
+# Code goes here
+```
+
+## Compliant Solution
+
+Introduction to the code example...
+
+*[compliant01.py](compliant01.py):*
+
+```python
+""" Compliant Code Example """
+
+# Code goes here
+
+#####################
+# Exploiting above code example
+#####################
+
+# Code goes here
+```
+
+## Automated Detection
+
+|Tool|Version|Checker|Description|
+|:---|:---|:---|:---|
+|Bandit|1.7.4 on Python 3.10.4|Not Available||
+|Flake8|8-4.0.1 on Python 3.10.4|Not Available||
+
+## Related Guidelines
+
+|||
+|:---|:---|
+|[MITRE CWE](http://cwe.mitre.org/)|Pillar: [CWE-000: Name of the pillar (4.13) (mitre.org)](https://cwe.mitre.org/data/definitions/000.html)|
+|[MITRE CWE](http://cwe.mitre.org/)|Base: [CWE-000: Numeric Truncation Error](https://cwe.mitre.org/data/definitions/000.html)|
+|[SEI CERT Coding Standard for Java](https://wiki.sei.cmu.edu/confluence/display/java/SEI+CERT+Oracle+Coding+Standard+for+Java)|[Reference Goes here](http://YOUR_LINK)|
+|[SEI CERT C Coding Standard](https://web.archive.org/web/20220511061752/https://wiki.sei.cmu.edu/confluence/display/c/SEI+CERT+C+Coding+Standard)|[Reference Goes here](http://YOUR_LINK)|
+|[ISO/IEC TR 24772:2019]|[Reference Goes here](http://YOUR_LINK)|
+
+## Bibliography
+
+|||
+|:---|:---|
+|[[Python docs](https://docs.python.org/3/reference/expressions.html#binary-arithmetic-operations)]|Python Software Foundation. (2024). Expressions, Title goes here [online]. Available from: [https://docs.python.org/3/reference/YOUR_LINK](https://docs.python.org/3/reference/YOUR_LINK) [accessed 1 January 2024] |
+
+When writing bibligraphy, follow the [Harvard reference guide](https://dkit.ie.libguides.com/harvard/citing-referencing)

--- a/docs/Secure-Coding-Guide-for-Python/contribution/README_TEMPLATE.md
+++ b/docs/Secure-Coding-Guide-for-Python/contribution/README_TEMPLATE.md
@@ -1,6 +1,8 @@
 # CWE-000: Title goes here
 
-Introduction paragraph...
+Introduction sentence, this will be displayed in search engines.
+
+Introduction paragraph, expanding on the introduction sentence...
 
 [*example01.py:*](example01.py)
 
@@ -28,11 +30,13 @@ Introduction to the code example...
 # Code goes here
 
 #####################
-# Exploiting above code example
+# Trying to exploit above code example
 #####################
 
 # Code goes here
 ```
+
+Short explanation of expected outcome of running the code example, e.g. "The code will ... throw an exception, print x..., loop forever..."
 
 ## Compliant Solution
 
@@ -46,11 +50,13 @@ Introduction to the code example...
 # Code goes here
 
 #####################
-# Exploiting above code example
+# Trying to exploit above code example
 #####################
 
 # Code goes here
 ```
+
+Short explanation of expected outcome of running the code example, e.g. "The code will ... throw an exception, print x..., loop forever..."
 
 ## Automated Detection
 

--- a/docs/Secure-Coding-Guide-for-Python/contribution/README_TEMPLATE.md
+++ b/docs/Secure-Coding-Guide-for-Python/contribution/README_TEMPLATE.md
@@ -70,7 +70,7 @@ Short explanation of expected outcome of running the code example, e.g. "The cod
 |||
 |:---|:---|
 |[MITRE CWE](http://cwe.mitre.org/)|Pillar: [CWE-000: Name of the pillar (4.13) (mitre.org)](https://cwe.mitre.org/data/definitions/000.html)|
-|[MITRE CWE](http://cwe.mitre.org/)|Base: [CWE-000: Numeric Truncation Error](https://cwe.mitre.org/data/definitions/000.html)|
+|[MITRE CWE](http://cwe.mitre.org/)|Base/Class (choose which one it is based on the abstraction on the CWE page): [CWE-000: Numeric Truncation Error](https://cwe.mitre.org/data/definitions/000.html)|
 |[SEI CERT Coding Standard for Java](https://wiki.sei.cmu.edu/confluence/display/java/SEI+CERT+Oracle+Coding+Standard+for+Java)|[Reference Goes here](http://YOUR_LINK)|
 |[SEI CERT C Coding Standard](https://web.archive.org/web/20220511061752/https://wiki.sei.cmu.edu/confluence/display/c/SEI+CERT+C+Coding+Standard)|[Reference Goes here](http://YOUR_LINK)|
 |[ISO/IEC TR 24772:2019]|[Reference Goes here](http://YOUR_LINK)|


### PR DESCRIPTION
The change aims to create a simple template for creating README files for Secure Coding Python Guides. By using the template, we can ensure that all of the rule descriptions follow the same format in regard to page sections, code examples, bibliography, etc. The template also contains the link to quoting reference guide we have decided to follow.

The template should be mentioned on the landing page referenced in #520