### PR TITLE
Changed wording to quote OpenSSF as main contributor

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/Intro_to_multiprocessing_and_multithreading/readme.md
+++ b/docs/Secure-Coding-Guide-for-Python/Intro_to_multiprocessing_and_multithreading/readme.md
@@ -3,7 +3,7 @@
 This page aims to explain the concepts that could be found in the following rules:
 
 - [CWE-410: Insufficient Resource Pool](../CWE-664/CWE-410/README.md)
-- [CWE-833: Deadlock - Development Environment - eTeamSpace (ericsson.com)](../CWE-664/CWE-833/README.md)
+- [CWE-833: Deadlock](../CWE-664/CWE-833/README.md)
 - [CWE-400: Uncontrolled Resource Consumption](../CWE-664/CWE-400/README.md)
 - [CWE-392: Missing Report of Error Condition](../CWE-703/CWE-392/README.md)
 - [CWE-665: Improper Initialization](../CWE-664/CWE-665/README.md)

--- a/docs/Secure-Coding-Guide-for-Python/readme.md
+++ b/docs/Secure-Coding-Guide-for-Python/readme.md
@@ -5,7 +5,7 @@ and non-compliant code with `CPython >= 3.9` using modules listed on
 
 [Python Module Index](https://docs.python.org/3.9/py-modindex.html) [Python 2023].
 
-This page is in initiative by Ericsson to improve secure coding in Python by providing a location for study. Its structure is based on
+This page is in initiative by OpenSSF  to improve secure coding in Python by providing a location for study. Its structure is based on
 Common Weakness Enamurator (CWE) [Pillar Weakness](https://cwe.mitre.org/documents/glossary/#Pillar%20Weakness) [mitre.org 2023].
 It currently contains *only* the code examples, documentation will follow.
 


### PR DESCRIPTION
Making sure that we only quote OpenSSF as contributor to the Python Secure Coding content.
Updated main readme with a link to the issue that brings in all the missing docs.