### PR TITLE
Add Jekyll-generated site, metadata, and cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ jspm_packages/
 
 # Optional npm cache directory
 .npm
+
+# Jekyll-generated site, metadata, and cache
+_site
+docs/.jekyll-metadata
+docs/.sass-cache/


### PR DESCRIPTION
This improves the experience when previewing the generated site using a local Jekyll instance