### PR TITLE
pySCG: adding prominent CVE for CWE-78 to main readme

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-78/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-78/README.md
@@ -40,7 +40,6 @@ This scenario demonstrates a potential remote command execution. The `FileOperat
 *[noncompliant01.py](noncompliant01.py):*
 
 ```python
-""" Non-compliant Code Example """
 # SPDX-FileCopyrightText: OpenSSF project contributors
 # SPDX-License-Identifier: MIT
 """ Non-compliant Code Example """
@@ -135,8 +134,6 @@ The `compliant01.py` code using the cross-platform compatible pathlib module and
 *[compliant01.py](compliant01.py):*
 
 ```python
-""" Compliant Code Example """
-
 # SPDX-FileCopyrightText: OpenSSF project contributors
 # SPDX-License-Identifier: MIT
 """ Compliant Code Example """

--- a/docs/Secure-Coding-Guide-for-Python/readme.md
+++ b/docs/Secure-Coding-Guide-for-Python/readme.md
@@ -88,7 +88,6 @@ It is **not production code** and requires code-style or python best practices t
 |[CWE-707: Improper Neutralization](https://cwe.mitre.org/data/definitions/707.html)|Prominent CVE|
 |:----------------------------------------------------------------|:----|
 |[CWE-78: Improper Neutralization of Special Elements Used in an OS Command ("OS Command Injection")](CWE-707/CWE-78/README.md)|[CVE-2024-43804](https://www.cvedetails.com/cve/CVE-2024-43804/),<br/>CVSSv3.1: **8.8**,<br/>EPSS: **00.06** (08.11.2024)|
-|[CWE-117: Improper Output Neutralization for Logs](CWE-707/CWE-117/.)|
 |[CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')](CWE-707/CWE-89/.)|[CVE-2019-8600](https://www.cvedetails.com/cve/CVE-2019-8600/),<br/>CVSSv3.1: **9.8**,<br/>EPSS: **01.43** (18.02.2024)|
 |[CWE-117: Improper Output Neutralization for Logs](CWE-707/CWE-117/.)||
 |[CWE-180: Incorrect behavior order: Validate before Canonicalize](CWE-707/CWE-180/.)|[CVE-2022-26136](https://www.cvedetails.com/cve/CVE-2022-26136/),<br/>CVSSv3.1: **9.8**,<br/>EPSS: **00.77** (05.11.2024)|

--- a/docs/Secure-Coding-Guide-for-Python/readme.md
+++ b/docs/Secure-Coding-Guide-for-Python/readme.md
@@ -87,7 +87,8 @@ It is **not production code** and requires code-style or python best practices t
 
 |[CWE-707: Improper Neutralization](https://cwe.mitre.org/data/definitions/707.html)|Prominent CVE|
 |:----------------------------------------------------------------|:----|
-|[CWE-78: Improper Neutralization of Special Elements Used in an OS Command ("OS Command Injection")](CWE-707/CWE-78/README.md)||
+|[CWE-78: Improper Neutralization of Special Elements Used in an OS Command ("OS Command Injection")](CWE-707/CWE-78/README.md)|[CVE-2024-43804](https://www.cvedetails.com/cve/CVE-2024-43804/),<br/>CVSSv3.1: **8.8**,<br/>EPSS: **00.06** (08.11.2024)|
+|[CWE-117: Improper Output Neutralization for Logs](CWE-707/CWE-117/.)|
 |[CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')](CWE-707/CWE-89/.)|[CVE-2019-8600](https://www.cvedetails.com/cve/CVE-2019-8600/),<br/>CVSSv3.1: **9.8**,<br/>EPSS: **01.43** (18.02.2024)|
 |[CWE-117: Improper Output Neutralization for Logs](CWE-707/CWE-117/.)||
 |[CWE-180: Incorrect behavior order: Validate before Canonicalize](CWE-707/CWE-180/.)|[CVE-2022-26136](https://www.cvedetails.com/cve/CVE-2022-26136/),<br/>CVSSv3.1: **9.8**,<br/>EPSS: **00.77** (05.11.2024)|


### PR DESCRIPTION
Adding [CVE-2024-43804](https://nvd.nist.gov/vuln/detail/CVE-2024-43804)  into main readme table for CWE-78