### PR TITLE
Fix typo in return value from README (fixes #652)

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/CWE-703/CWE-392/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-703/CWE-392/README.md
@@ -163,7 +163,7 @@ def map_threads(x):
             for res in result_gen:
                 ret.append(res)
                 invalid_arg += 1
-            return res
+            return ret
         except ValueError as e:
             # handle exception...
             raise ValueError(

--- a/docs/Secure-Coding-Guide-for-Python/CWE-703/CWE-392/compliant03.py
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-703/CWE-392/compliant03.py
@@ -19,7 +19,7 @@ def map_threads(x):
             for res in result_gen:
                 ret.append(res)
                 invalid_arg += 1
-            return res
+            return ret
         except ValueError as e:
             # handle exception...
             raise ValueError(


### PR DESCRIPTION
The code snippet incorrectly returns `res` when it should be returning `ret`. This doesn't really have an effect, since the sample demonstrates failing early.