### PR TITLE
Use OpenSSF brand colors, fixes #160

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -149,3 +149,22 @@ h2.nocount:before, h3.nocount:before, h4.nocount:before, h5.nocount:before, h6.n
 h1, h2, h3, h4, h5, h6 {
     break-after: avoid-page;
 }
+
+/* Set links to some color listed in the OpenSSF pallette in
+ * https://openssf.org/about/brand-guidelines/ */
+/* unvisited link */
+a:link {
+  color: #45208c;
+}
+/* visited link */
+a:visited {
+  color: #604693;
+}
+/* mouse over link */
+a:hover {
+  color: #170D34;
+}
+/* selected link */
+a:active {
+  color: #04ee5f;
+}


### PR DESCRIPTION
Switch to OpenSSF brand colors for hyperlink text. The OpenSSF Brand Guidelines are here:
https://openssf.org/about/brand-guidelines/

We changed best.openssf.org to use OpenSSF's fonts long ago, but we never changed the hyperlink colors to adhere to the guidelines. This commit changes hyperlinks to also use OpenSSF brand colors.

I intentionally chose dark colors to provide *strong* contrast with the white background.  This site provides mostly documents, with with text that is smaller than the main OpenSSF website. So ensuring we have *good* contrast between the text and the background seemed especially important.

For more about changing link colors, see:
https://www.w3schools.com/css/css_link.asp

I suggest that we can argue about changing these colors later. Once this commit is accepted, it's much easier to change the colors again :-).