### PR TITLE
Create/implement separate hello.js for hello.html config

### DIFF
--- a/docs/labs/create_checker.md
+++ b/docs/labs/create_checker.md
@@ -78,6 +78,11 @@ Modify the `expected0` section to have a sample expected answer, and
 See [input1.html](input1.html) and [input2.html](input2.html)
 for examples.
 
+*NOTE*: We are transitioning to using separate `.js` files to simplify
+translations. E.g., `input1.html` will have a corresponding `input1.js`
+with configuration information that is shared between translations.
+That transition hasn't completed yet.
+
 Whenever a lab is loaded it automatically runs all embedded self-tests.
 At the least, it checks that the initial attempted answer does
 *not* satisfy the correct answer pattern, while the example expected answer
@@ -745,6 +750,25 @@ In the future we may pull the YAML data into a separate file, with
 different markers for the text of various locales.
 E.g., `text` would be English, and `text_jp` would its Japanese translation.
 We'd love feedback on this idea.
+
+## Conversion of YAML to JavaScript files
+
+We have used embedded YAML in the HTML files for configuration.
+However, this creates a problem for translations: You want different
+HTML files for each translation (locale), yet the embedded YAML can't be shared.
+
+We have decided to move away from YAML for configuration to
+a lab-specific JavaScript file. That file can be loaded when the HTML
+is loaded, even when the HTML is loaded locally.
+
+You can start this conversion using the `yq` tool:
+
+~~~~sh
+yq eval hello.yaml -o=json -P > hello.js
+~~~~
+
+Prepend the result with `configurationInfo =` and suffix with `;`.
+Now load the JavaScript as a script (after the main library).
 
 ## Potential future directions
 

--- a/docs/labs/create_checker.md
+++ b/docs/labs/create_checker.md
@@ -78,11 +78,6 @@ Modify the `expected0` section to have a sample expected answer, and
 See [input1.html](input1.html) and [input2.html](input2.html)
 for examples.
 
-*NOTE*: We are transitioning to using separate `.js` files to simplify
-translations. E.g., `input1.html` will have a corresponding `input1.js`
-with configuration information that is shared between translations.
-That transition hasn't completed yet.
-
 Whenever a lab is loaded it automatically runs all embedded self-tests.
 At the least, it checks that the initial attempted answer does
 *not* satisfy the correct answer pattern, while the example expected answer
@@ -96,6 +91,19 @@ To submit new or updated labs, create a pull request on the
 under the `docs/labs` directory.
 Simply fork the repository, add your proposed lab in the `docs/labs` directory,
 and create a pull request.
+
+### Transitioning away from YAML
+
+Configuration data was originally in an embedded YAML file.
+We are transitioning to using separate `.js` files to simplify
+translations and eliminate the need for the YAML library.
+E.g., `input1.html` will have a corresponding `input1.js`
+with configuration information that is shared between translations.
+That transition hasn't completed yet.
+
+To help, you can create a JavaScript file that sets info2
+instead of info. The checker will automatically report
+any differences between the two values.
 
 ### Quick aside: script tag requirements
 

--- a/docs/labs/hello.html
+++ b/docs/labs/hello.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="checker.css">
 <script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
+<script src="hello.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">
 
 <!-- See create_labs.md for how to create your own lab! -->
@@ -20,98 +21,6 @@ console.log("Hello, world!");
 <script id="correct0" type="plain/text">
 \s* console \. log \( (["'`])Hello,\x20world!\1 \) ; \s*
 </script>
-
-<script id="info" type="application/yaml">
----
-hints:
-- absent: |-
-    ^ console \. log \(
-  text: ' Please use the form console.log("...");'
-  examples:
-  - - ""
-  - - "foo"
-- present: "Goodbye"
-  text: "You need to change the text Goodbye to something else."
-  examples:
-  - - 'console.log("Goodbye.");'
-- present: "hello"
-  text: "Please capitalize Hello."
-  examples:
-  - - 'console.log("hello.");'
-- present: "World"
-  text: "Please lowercase world."
-  examples:
-  - - 'console.log("Hello, World!");'
-- present: "Hello[^,]"
-  text: "Put a comma immediately after Hello."
-  examples:
-  - - 'console.log("Hello world.");'
-- present: "Hello"
-  absent: "[Ww]orld"
-  text: "There's a Hello, but you need to also mention the world."
-  examples:
-  - - 'console.log("Hello, ");'
-- present: |-
-             world[^\!]
-  text: "Put an exclamation point immediately after world."
-  examples:
-  - - 'console.log("Hello, world.");'
-- present: 'Hello,\s*world!'
-  absent: 'Hello,\x20world!'
-  text: "You need exactly one space between 'Hello,' and 'world!'"
-  examples:
-  - - 'console.log("Hello,     world!");'
-- present: |-
-              ^ console \. log \( Hello
-  text: |-
-          You must quote constant strings using ", ', or `
-  examples:
-  - - 'console.log(Hello, world'
-  - - 'console.log( Hello, world'
-- absent: " ; $"
-  text: >
-    Please end this statement with a semicolon. JavaScript does not
-    require a semicolon in this case,
-    but usually when modifying source code you should
-    follow the style of the current code.
-  examples:
-  - - '  console.log("Hello, world!")  '
-successes:
-- - ' console . log( "Hello, world!" ) ; '
-- - " console . log( 'Hello, world!' ) ; "
-- - " console . log( `Hello, world!` ) ; "
-failures:
-- - ' console . log( Hello, world! ) ; '
-- - ' console . log("hello, world!") ; '
-# ADVANCED use - define our own preprocessing commands.
-# I suggest using "|-" (stripping the trailing newlines)
-# preprocessing:
-#   -
-#     - |-
-#         [\n\r]+
-#     - ""
-#   -
-#     - |-
-#         (\\s\*)?\s+(\\s\*)?
-#     - "\\s*"
-# Here are tests for default preprocessing. You do not need this in
-# every lab, but it demonstrates how to do it.
-preprocessingTests:
-  -
-    - |-
-        \s* console \. log \( (["'`])Hello,\x20world!\1 \) ; \s*
-    - |-
-        \s*console\s*\.\s*log\s*\(\s*(["'`])Hello,\x20world!\1\s*\)\s*;\s*
-  -
-    - |-
-        \s* foo \s+ bar \\string\\ \s*
-    - |-
-        \s*foo\s+bar\s*\\string\\\s*
-# debug: true
-</script>
-<!--
-
--->
 
 </head>
 <body>

--- a/docs/labs/hello.js
+++ b/docs/labs/hello.js
@@ -1,0 +1,104 @@
+info =
+{
+  "hints": [
+    {
+      "absent": String.raw`^ console \. log \(`,
+      "text": " Please use the form console.log(\"...\");",
+      "examples": [
+        [ "" ],
+        [ "foo" ]
+      ]
+    },
+    {
+      "present": "Goodbye",
+      "text": "You need to change the text Goodbye to something else.",
+      "examples": [
+        [ "console.log(\"Goodbye.\");" ]
+      ]
+    },
+    {
+      "present": "hello",
+      "text": "Please capitalize Hello.",
+      "examples": [
+        [ "console.log(\"hello.\");" ]
+      ]
+    },
+    {
+      "present": "World",
+      "text": "Please lowercase world.",
+      "examples": [
+        [ "console.log(\"Hello, World!\");" ]
+      ]
+    },
+    {
+      "present": "Hello[^,]",
+      "text": "Put a comma immediately after Hello.",
+      "examples": [
+        [ "console.log(\"Hello world.\");" ]
+      ]
+    },
+    {
+      "present": "Hello",
+      "absent": "[Ww]orld",
+      "text": "There's a Hello, but you need to also mention the world.",
+      "examples": [
+        [ "console.log(\"Hello, \");" ]
+      ]
+    },
+    {
+      "present": String.raw`world[^\!]`,
+      "text": "Put an exclamation point immediately after world.",
+      "examples": [
+        [ "console.log(\"Hello, world.\");" ]
+      ]
+    },
+    {
+      "present": String.raw`Hello,\s*world!`,
+      "absent": String.raw`Hello,\x20world!`,
+      "text": "You need exactly one space between 'Hello,' and 'world!'",
+      "examples": [
+        [ "console.log(\"Hello,     world!\");" ]
+      ]
+    },
+    {
+      "present": String.raw`^ console \. log \( Hello`,
+      "text": "You must quote constant strings using \", ', or `",
+      "examples": [
+        [ "console.log(Hello, world" ],
+        [ "console.log( Hello, world" ]
+      ]
+    },
+    {
+      "absent": String.raw` ; $`,
+      "text": "Please end this statement with a semicolon. JavaScript does not require a semicolon in this case, but usually when modifying source code you should follow the style of the current code.\n",
+      "examples": [
+        [ "  console.log(\"Hello, world!\")  " ]
+      ]
+    }
+  ],
+  "successes": [
+    [ " console . log( \"Hello, world!\" ) ; " ],
+    [ " console . log( 'Hello, world!' ) ; " ],
+    [ " console . log( `Hello, world!` ) ; " ]
+  ],
+  "failures": [
+    [ " console . log( Hello, world! ) ; " ],
+    [ " console . log(\"hello, world!\") ; " ]
+  ],
+  // All regexes are preprocessed by a set of rules. You can replace them with your
+  // own set. You can completely eliminate them by providing an empty set of rules:
+  // "preprocessing" : [ ],
+  // Here are tests for default preprocessing. You do not need this in
+  // every lab, but it demonstrates how to create tests for your preprocessing.
+  "preprocessingTests": [
+    [
+      String.raw`\s* console \. log \( (["'${BACKQUOTE}])Hello,\x20world!\1 \) ; \s*`,
+      String.raw`\s*console\s*\.\s*log\s*\(\s*(["'${BACKQUOTE}])Hello,\x20world!\1\s*\)\s*;\s*`
+    ],
+    [
+      String.raw`\s* foo \s+ bar \\string\\ \s*`,
+      String.raw`\s*foo\s+bar\s*\\string\\\s*`
+    ]
+
+  ]
+};

--- a/docs/labs/hello.js
+++ b/docs/labs/hello.js
@@ -1,87 +1,66 @@
 info =
 {
-  "hints": [
+  hints: [
     {
-      "absent": String.raw`^ console \. log \(`,
-      "text": " Please use the form console.log(\"...\");",
-      "examples": [
-        [ "" ],
-        [ "foo" ]
+      absent: String.raw`^ console \. log \(`,
+      text: "Please use the form console.log(\"...\");",
+      examples: [ [ "" ], [ "foo" ]
       ]
     },
     {
-      "present": "Goodbye",
-      "text": "You need to change the text Goodbye to something else.",
-      "examples": [
-        [ "console.log(\"Goodbye.\");" ]
-      ]
+      present: "Goodbye",
+      text: "You need to change the text Goodbye to something else.",
+      examples: [ [ "console.log(\"Goodbye.\");" ] ]
     },
     {
-      "present": "hello",
-      "text": "Please capitalize Hello.",
-      "examples": [
-        [ "console.log(\"hello.\");" ]
-      ]
+      present: "hello",
+      text: "Please capitalize Hello.",
+      examples: [ [ "console.log(\"hello.\");" ] ]
     },
     {
-      "present": "World",
-      "text": "Please lowercase world.",
-      "examples": [
-        [ "console.log(\"Hello, World!\");" ]
-      ]
+      present: "World",
+      text: "Please lowercase world.",
+      examples: [ [ "console.log(\"Hello, World!\");" ] ]
     },
     {
-      "present": "Hello[^,]",
-      "text": "Put a comma immediately after Hello.",
-      "examples": [
-        [ "console.log(\"Hello world.\");" ]
-      ]
+      present: "Hello[^,]",
+      text: "Put a comma immediately after Hello.",
+      examples: [ [ "console.log(\"Hello world.\");" ] ]
     },
     {
-      "present": "Hello",
-      "absent": "[Ww]orld",
-      "text": "There's a Hello, but you need to also mention the world.",
-      "examples": [
-        [ "console.log(\"Hello, \");" ]
-      ]
+      present: "Hello",
+      absent: "[Ww]orld",
+      text: "There's a Hello, but you need to also mention the world.",
+      examples: [ [ "console.log(\"Hello, \");" ] ]
     },
     {
-      "present": String.raw`world[^\!]`,
-      "text": "Put an exclamation point immediately after world.",
-      "examples": [
-        [ "console.log(\"Hello, world.\");" ]
-      ]
+      present: String.raw`world[^\!]`,
+      text: "Put an exclamation point immediately after world.",
+      examples: [ [ "console.log(\"Hello, world.\");" ] ]
     },
     {
-      "present": String.raw`Hello,\s*world!`,
-      "absent": String.raw`Hello,\x20world!`,
-      "text": "You need exactly one space between 'Hello,' and 'world!'",
-      "examples": [
-        [ "console.log(\"Hello,     world!\");" ]
-      ]
+      present: String.raw`Hello,\s*world!`,
+      absent: String.raw`Hello,\x20world!`,
+      text: "You need exactly one space between 'Hello,' and 'world!'",
+      examples: [ [ "console.log(\"Hello,     world!\");" ] ]
     },
     {
-      "present": String.raw`^ console \. log \( Hello`,
-      "text": "You must quote constant strings using \", ', or `",
-      "examples": [
-        [ "console.log(Hello, world" ],
-        [ "console.log( Hello, world" ]
-      ]
+      present: String.raw`^ console \. log \( Hello`,
+      text: "You must quote constant strings using \", ', or `",
+      examples: [ [ "console.log(Hello, world" ], [ "console.log( Hello, world" ] ]
     },
     {
-      "absent": String.raw` ; $`,
-      "text": "Please end this statement with a semicolon. JavaScript does not require a semicolon in this case, but usually when modifying source code you should follow the style of the current code.\n",
-      "examples": [
-        [ "  console.log(\"Hello, world!\")  " ]
-      ]
+      absent: String.raw` ; $`,
+      text: "Please end this statement with a semicolon. JavaScript does not require a semicolon in this case, but usually when modifying source code you should follow the style of the current code.\n",
+      examples: [ [ "  console.log(\"Hello, world!\")  " ] ]
     }
   ],
-  "successes": [
+  successes: [
     [ " console . log( \"Hello, world!\" ) ; " ],
     [ " console . log( 'Hello, world!' ) ; " ],
     [ " console . log( `Hello, world!` ) ; " ]
   ],
-  "failures": [
+  failures: [
     [ " console . log( Hello, world! ) ; " ],
     [ " console . log(\"hello, world!\") ; " ]
   ],
@@ -99,6 +78,5 @@ info =
       String.raw`\s* foo \s+ bar \\string\\ \s*`,
       String.raw`\s*foo\s+bar\s*\\string\\\s*`
     ]
-
   ]
 };

--- a/docs/labs/hello.js
+++ b/docs/labs/hello.js
@@ -3,55 +3,65 @@ info =
   hints: [
     {
       absent: String.raw`^ console \. log \(`,
-      text: "Please use the form console.log(\"...\");",
+      text: "Please use the form console.log(...);",
+      text_ja: "console.log(...); の形式を使用してください。",
       examples: [ [ "" ], [ "foo" ]
       ]
     },
     {
       present: "Goodbye",
       text: "You need to change the text Goodbye to something else.",
+      text_ja: "「Goodbye」というテキストを別の文字に変更する必要があります.",
       examples: [ [ "console.log(\"Goodbye.\");" ] ]
     },
     {
       present: "hello",
       text: "Please capitalize Hello.",
+      text_ja: "Hello は大文字で入力してください。.",
       examples: [ [ "console.log(\"hello.\");" ] ]
     },
     {
       present: "World",
       text: "Please lowercase world.",
+      text_ja: "world という単語を小文字にしてください。",
       examples: [ [ "console.log(\"Hello, World!\");" ] ]
     },
     {
       present: "Hello[^,]",
       text: "Put a comma immediately after Hello.",
+      text_ja: "Hello の直後にカンマを入れます",
       examples: [ [ "console.log(\"Hello world.\");" ] ]
     },
     {
       present: "Hello",
       absent: "[Ww]orld",
       text: "There's a Hello, but you need to also mention the world.",
+      text_ja: "「Hello」がありますが、「world」という単語にも言及する必要があります。",
       examples: [ [ "console.log(\"Hello, \");" ] ]
     },
     {
       present: String.raw`world[^\!]`,
       text: "Put an exclamation point immediately after world.",
+      text_ja: "world の直後に感嘆符を置きます。",
       examples: [ [ "console.log(\"Hello, world.\");" ] ]
     },
     {
       present: String.raw`Hello,\s*world!`,
       absent: String.raw`Hello,\x20world!`,
       text: "You need exactly one space between 'Hello,' and 'world!'",
+      text_ja: "「Hello」と「world!」の間にはスペースが 1 つだけ必要です。",
       examples: [ [ "console.log(\"Hello,     world!\");" ] ]
     },
     {
       present: String.raw`^ console \. log \( Hello`,
       text: "You must quote constant strings using \", ', or `",
+      text_ja: "定数文字列は \"、'、または ` を使用して引用符で囲む必要があります。",
       examples: [ [ "console.log(Hello, world" ], [ "console.log( Hello, world" ] ]
     },
     {
       absent: String.raw` ; $`,
-      text: "Please end this statement with a semicolon. JavaScript does not require a semicolon in this case, but usually when modifying source code you should follow the style of the current code.\n",
+      text: "Please end this statement with a semicolon. JavaScript does not require a semicolon in this case, but usually when modifying source code you should follow the style of the current code.",
+      text_ja: "このステートメントはセミコロンで終了してください。この場合、JavaScript ではセミコロンは必要ありませんが、通常、ソース コードを変更する場合は、現在のコードのスタイルに従う必要があります。",
       examples: [ [ "  console.log(\"Hello, world!\")  " ] ]
     }
   ],
@@ -67,8 +77,8 @@ info =
   // All regexes are preprocessed by a set of rules. You can replace them with your
   // own set. You can completely eliminate them by providing an empty set of rules:
   // "preprocessing" : [ ],
-  // Here are tests for default preprocessing. You do not need this in
-  // every lab, but it demonstrates how to create tests for your preprocessing.
+  // Here are tests for default preprocessing.
+  // Don't do this in every lab. This merely demonstrates how to create tests for your preprocessing.
   "preprocessingTests": [
     [
       String.raw`\s* console \. log \( (["'${BACKQUOTE}])Hello,\x20world!\1 \) ; \s*`,


### PR DESCRIPTION
Currently configuration is mostly in a YAML file embedded in the lab's HTML. This means that the lab configuration cannot be shared between locales (translations), which is annoying.

We can't easily load YAML or JSON from a separate file when running or testing locally. However, we *can* easily load a separate file if it's in JavaScript format.

This switches the configuration of lab hello.html so it uses the configuration in hello.js.