### PR TITLE
Lab redos: Move answers to shared JavaScript

### DIFF
--- a/docs/labs/redos.html
+++ b/docs/labs/redos.html
@@ -12,19 +12,6 @@
 
 <!-- See create_labs.md for how to create your own lab! -->
 
-<!-- Sample expected answer -->
-<script id="expected0" type="plain/text">
-  query('id').isLength({max:50}).matches( /^[A-Z0-9]+$/ ),
-</script>
-
-<!-- Full pattern of correct answer -->
-<script id="correct0" type="plain/text">
-\s* query \( ('id'|"id"|`id`) \)
-\. isLength \( \{ max: 50 ,? \} \)
-\. matches \( \/\^\[A-Z0-9\]\+\$\/ \) , \s*
-</script>
-
-
 </head>
 <body>
 <!-- For GitHub Pages formatting: -->

--- a/docs/labs/redos.js
+++ b/docs/labs/redos.js
@@ -71,5 +71,20 @@ info =
       present: String.raw`\[0-9[Aa]-[Zz]\]`,
       text: "It's conventional to list letters first, so use [A-Z0-9] not [0-9A-Z]"
     }
-  ]
+  ],
+  expected: [
+    "query('id').isLength({max:50}).matches( /^[A-Z0-9]+$/ ),",
+  ],
+  correct: [
+    String.raw`\s* query \(
+      ('id'|"id"|${BACKQUOTE}id${BACKQUOTE}) \)
+      \. isLength \( \{ max: 50 ,? \} \)
+      \. matches \( \/\^\[A-Z0-9\]\+\$\/ \) , \s*`,
+  ],
+  successes: [
+    [ " query ( `id` ) . isLength( {max:50} ).matches( /^[A-Z0-9]+$/ ) , " ],
+  ],
+  failures: [
+    [ "query('id').isLength({max:50}).matches( /^[A-Z]+$/ ),", ],
+  ],
 }


### PR DESCRIPTION
We're removing the YAML and moving the answers to a shared JavaScript so that we can easily internationalize (and remove a library we don't really need). I believe this is the last one.