### PR TITLE
Remove YAML processing library

### DIFF
--- a/docs/labs/argument-injection.html
+++ b/docs/labs/argument-injection.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="argument-injection.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/assert.html
+++ b/docs/labs/assert.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="assert.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/conversion.html
+++ b/docs/labs/conversion.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="conversion.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/csp1.html
+++ b/docs/labs/csp1.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="csp1.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/deserialization.html
+++ b/docs/labs/deserialization.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="deserialization.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/format-strings.html
+++ b/docs/labs/format-strings.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="format-strings.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/free.html
+++ b/docs/labs/free.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="free.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/handling-errors.html
+++ b/docs/labs/handling-errors.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="handling-errors.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/hardcoded.html
+++ b/docs/labs/hardcoded.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="hardcoded.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/hello.html
+++ b/docs/labs/hello.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="hello.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/input1.html
+++ b/docs/labs/input1.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="input1.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/input2.html
+++ b/docs/labs/input2.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="input2.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/ja_hello.html
+++ b/docs/labs/ja_hello.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="hello.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/oob1.html
+++ b/docs/labs/oob1.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="oob1.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/redos.html
+++ b/docs/labs/redos.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="redos.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/regex0.html
+++ b/docs/labs/regex0.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="regex0.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/regex1.html
+++ b/docs/labs/regex1.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="regex1.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/shell-injection.html
+++ b/docs/labs/shell-injection.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="shell-injection.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/sql-injection.html
+++ b/docs/labs/sql-injection.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="sql-injection.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/template.html
+++ b/docs/labs/template.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="template.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">

--- a/docs/labs/xss.html
+++ b/docs/labs/xss.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://best.openssf.org/assets/css/style.css">
 <link rel="stylesheet" href="checker.css">
-<script src="js-yaml.min.js"></script>
 <script src="checker.js"></script>
 <script src="xss.js"></script>
 <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">


### PR DESCRIPTION
We've switched from using YAML to using JavaScript directly for storing data. One reason to do that was simply that it's the only easy way to load data when running locally.

A second reason, however, is that this means we can completely eliminate the use of this library at run-time. Not using a library at *all* eliminates the need to maintain it, update it, etc. It also speeds loading; nothing loads faster than code you don't load at all :-).