### PR TITLE
Add trailing commas to text lines

### DIFF
--- a/docs/labs/argument-injection.js
+++ b/docs/labs/argument-injection.js
@@ -3,73 +3,73 @@ info =
   hints: [
     {
       present: String.raw`exec \(`,
-      text: "The `exec` function is vulnerable to command injection. Replace it with `execFile` to improve security."
+      text: "The `exec` function is vulnerable to command injection. Replace it with `execFile` to improve security.",
     },
     {
       absent: String.raw`^[\n\r]*\s*execFile\s*\(`,
-      text: "Use the `execFile` function instead of `exec` to avoid shell interpretation. Your line should start with `execFile(`."
+      text: "Use the `execFile` function instead of `exec` to avoid shell interpretation. Your line should start with `execFile(`.",
     },
     {
       absent: String.raw`execFile\s*\(\s*['"${BACKQUOTE}]git['"${BACKQUOTE}]\s*,`,
-      text: "Separate the command and its arguments. The first argument to `execFile` should be the command 'git' without any of the command arguments."
+      text: "Separate the command and its arguments. The first argument to `execFile` should be the command 'git' without any of the command arguments.",
     },
     {
       present: String.raw`['"${BACKQUOTE}]git\x20blame['"${BACKQUOTE}]`,
-      text: "Separate the command and its arguments. The first argument to `execFile` should be the command 'git', followed by an array with parameters, like this: `execFile('git', ['blame', ...])`."
+      text: "Separate the command and its arguments. The first argument to `execFile` should be the command 'git', followed by an array with parameters, like this: `execFile('git', ['blame', ...])`.",
     },
     {
       absent: String.raw`\[ ['"${BACKQUOTE}]blame`,
-      text: "Pass the arguments as an array, like this: `execFile('git', ['blame', ...])`."
+      text: "Pass the arguments as an array, like this: `execFile('git', ['blame', ...])`.",
     },
     {
       present: "--",
       absent: String.raw`['"${BACKQUOTE}]--['"${BACKQUOTE}]`,
-      text: "To pass `--` you need to pass it as a literal string. Typically this is notated as `'--'` or `\"--\"`."
+      text: "To pass `--` you need to pass it as a literal string. Typically this is notated as `'--'` or `\"--\"`.",
     },
     {
       absent: String.raw`\[ ['"${BACKQUOTE}]blame['"${BACKQUOTE}] , ['"${BACKQUOTE}]--['"${BACKQUOTE}] ,`,
-      text: "Pass the arguments as an array. Include '--' before the file path to prevent argument injection. Your array should look like `['blame', '--', ...`."
+      text: "Pass the arguments as an array. Include '--' before the file path to prevent argument injection. Your array should look like `['blame', '--', ...`.",
     },
     {
       present: String.raw`['"${BACKQUOTE}]filePath['"${BACKQUOTE}]`,
-      text: "`filePath` is a variable, use it directly without using quote marks."
+      text: "`filePath` is a variable, use it directly without using quote marks.",
     },
     {
       present: String.raw`['"]\$\{filePath\}['"]`,
-      text: "`filePath` is a variable, use it directly without using quote marks."
+      text: "`filePath` is a variable, use it directly without using quote marks.",
     },
     {
       present: String.raw`${BACKQUOTE}\$\{filePath\}${BACKQUOTE}`,
-      text: "Strictly speaking, using a backquoted template with a single reference to a variable name works. In this case, it's being done to `filePath`. However, this is unnecessarily complicated. When you want to simply refer to a variable's value, use the variable name."
+      text: "Strictly speaking, using a backquoted template with a single reference to a variable name works. In this case, it's being done to `filePath`. However, this is unnecessarily complicated. When you want to simply refer to a variable's value, use the variable name.",
     },
     {
       absent: String.raw`\[ ['"${BACKQUOTE}]blame['"${BACKQUOTE}] , ['"${BACKQUOTE}]--['"${BACKQUOTE}] , filePath \]`,
-      text: "Pass the arguments as an array. Include '--' before the file path to prevent argument injection. Your array should look like `['blame', '--', filePath]`."
+      text: "Pass the arguments as an array. Include '--' before the file path to prevent argument injection. Your array should look like `['blame', '--', filePath]`.",
     },
     {
       present: "shell = [fF]alse",
-      text: "When passing options to execFile, you need an option with the options, and those use `:` not `=`. So you should say something like: `{shell: false}`."
+      text: "When passing options to execFile, you need an option with the options, and those use `:` not `=`. So you should say something like: `{shell: false}`.",
     },
     {
       present: "[F]alse",
-      text: "JavaScript is case-sensitive. The false value is spelled as `false` and not `False`."
+      text: "JavaScript is case-sensitive. The false value is spelled as `false` and not `False`.",
     },
     {
       absent: String.raw`\{ shell : false \}`,
       present: "shell : false",
-      text: "When passing options to execFile, you must provide those options as a JavaScript object. That means you must surround them with `{...}` like this: `{shell: false}`."
+      text: "When passing options to execFile, you must provide those options as a JavaScript object. That means you must surround them with `{...}` like this: `{shell: false}`.",
     },
     {
       absent: String.raw`\{ shell : false \}`,
-      text: "We encourage you to explicitly set `shell: false` in the options object to prevent shell interpretation. That is something like this: `execFile('git', ['blame', '--', filePath], { shell: false }, ...`"
+      text: "We encourage you to explicitly set `shell: false` in the options object to prevent shell interpretation. That is something like this: `execFile('git', ['blame', '--', filePath], { shell: false }, ...`",
     },
     {
       absent: String.raw`\(\s*[a-zA-Z_$][a-zA-Z0-9_$]*\s*,\s*[a-zA-Z_$][a-zA-Z0-9_$]*\s*,\s*[a-zA-Z_$][a-zA-Z0-9_$]*\s*\)\s*=>`,
-      text: "Maintain the callback function structure with three parameters (typically named error, stdout, and stderr, but any valid variable names are acceptable)."
+      text: "Maintain the callback function structure with three parameters (typically named error, stdout, and stderr, but any valid variable names are acceptable).",
     },
     {
       present: String.raw`\) \) =>`,
-      text: "The `exec` function should be closed in later lines, not here."
+      text: "The `exec` function should be closed in later lines, not here.",
     },
   ],
   expected: [

--- a/docs/labs/assert.js
+++ b/docs/labs/assert.js
@@ -17,11 +17,11 @@ info =
     },
     {
       present: "(bindingresult|BindingResult)",
-      text: "Java is case-sensitive. Use `bindingResult`, not `bindingresult` nor `BindingResult`."
+      text: "Java is case-sensitive. Use `bindingResult`, not `bindingresult` nor `BindingResult`.",
     },
     {
       present: "(haserrors|HasErrors)",
-      text: "Java is case-sensitive. Use `hasErrors`, not `haserrors` nor `HasErrors`."
+      text: "Java is case-sensitive. Use `hasErrors`, not `haserrors` nor `HasErrors`.",
     },
     {
       present: String.raw`^\s*if\s*[^\(\s]`,
@@ -39,25 +39,25 @@ info =
     },
     {
       absent: String.raw`^ if \( bindingResult \. hasErrors \( \) \) `,
-      text: "Begin the answer with the text `if (bindingResult.hasErrors())` so that a statement will be executed if that condition is true."
+      text: "Begin the answer with the text `if (bindingResult.hasErrors())` so that a statement will be executed if that condition is true.",
     },
     {
       present: String.raw`if \( bindingResult \. hasErrors \( \) \) [^\{\s] `,
-      text: "Follow the conditional with an open brace, e.g., `if (bindingResult.hasErrors()) {...`."
+      text: "Follow the conditional with an open brace, e.g., `if (bindingResult.hasErrors()) {...`.",
     },
     {
       absent: String.raw`return "form"
 `,
-      text: "You need to use `return \"form\";` somewhere."
+      text: "You need to use `return \"form\";` somewhere.",
     },
     {
       present: String.raw`return "form"`,
       absent: String.raw`return "form" ;`,
-      text: "You need to use `;` (semicolon) after `return \"form\"` because in Java statements must be followed by a semicolon."
+      text: "You need to use `;` (semicolon) after `return \"form\"` because in Java statements must be followed by a semicolon.",
     },
     {
       absent: String.raw`\} $`,
-      text: "The answer needs to end with `}` (closing brace)."
+      text: "The answer needs to end with `}` (closing brace).",
     },
   ],
   expected: [

--- a/docs/labs/conversion.js
+++ b/docs/labs/conversion.js
@@ -3,11 +3,11 @@ info =
   hints: [
     {
       absent: "unsigned",
-      text: "The type defined for queue_count should exactly match the return type of get_queue."
+      text: "The type defined for queue_count should exactly match the return type of get_queue.",
     },
     {
       present: String.raw`unsigned\s+queue_count`,
-      text: "The declared return type of get_queue is `unsigned int`; you should match it exactly instead of using a synonym like `unsigned`."
+      text: "The declared return type of get_queue is `unsigned int`; you should match it exactly instead of using a synonym like `unsigned`.",
     },
   ],
   expected: [

--- a/docs/labs/csp1.js
+++ b/docs/labs/csp1.js
@@ -12,7 +12,7 @@ info =
     },
     {
       absent: "const",
-      text: "Start with const."
+      text: "Start with const.",
     },
     {
       absent: String.raw`const\s+helmet =`,
@@ -39,14 +39,14 @@ info =
     {
       absent: String.raw`\s* app \. use \( helmet \( \{`,
       index: 1,
-      text: "Your code should begin with app.use(helmet({"
+      text: "Your code should begin with app.use(helmet({",
     },
     {
       absent: String.raw`\s* app \. use \( helmet \( \{
       contentSecurityPolicy: \{ \s*
 `,
       index: 1,
-      text: "Your code should begin with:\napp.use(helmet({\n  contentSecurityPolicy: {\n"
+      text: "Your code should begin with:\napp.use(helmet({\n  contentSecurityPolicy: {\n",
     },
     {
       absent: String.raw`\s* app \. use \( helmet \( \{
@@ -54,7 +54,7 @@ info =
         directives: \{ \s*
 `,
       index: 1,
-      text: "Your code should begin with:\napp.use(helmet({\n  contentSecurityPolicy: {\n        directives: {\n"
+      text: "Your code should begin with:\napp.use(helmet({\n  contentSecurityPolicy: {\n        directives: {\n",
     },
     {
       absent: String.raw`\s* app \. use \( helmet \( \{
@@ -63,26 +63,26 @@ info =
             "script-src": \[ "'self'" , ["']https://example.com["'] \] , \s*
 `,
       index: 1,
-      text: "Your code should continue with:\napp.use(helmet({\n  contentSecurityPolicy: {\n        directives: {\n          \"script-src\": [\"'self'\", \"https://example.com\"],\n"
+      text: "Your code should continue with:\napp.use(helmet({\n  contentSecurityPolicy: {\n        directives: {\n          \"script-src\": [\"'self'\", \"https://example.com\"],\n",
     },
     {
       absent: String.raw`"style-src": \[ "'self'" \]
 `,
       index: 1,
-      text: "Don't forget to include \"style-src\": [\"'self'\"]\n"
+      text: "Don't forget to include \"style-src\": [\"'self'\"]\n",
     },
     {
       absent: "; $",
       index: 1,
-      text: "JavaScript doesn''t require semicolon terminators, but the rest of the code uses them. You should try to match a coding style when modifying existing code unless there''s an important reason not to. Please update the second statement to use a semicolon terminator."
+      text: "JavaScript doesn''t require semicolon terminators, but the rest of the code uses them. You should try to match a coding style when modifying existing code unless there''s an important reason not to. Please update the second statement to use a semicolon terminator.",
     },
     {
       absent: String.raw`\} \} \) \) ; $`,
       index: 1,
-      text: "The correct answer is expected to end with `} } ) ) ;` ignoring whitespace. Check that you have matching parentheses and braces."
+      text: "The correct answer is expected to end with `} } ) ) ;` ignoring whitespace. Check that you have matching parentheses and braces.",
     },
     {
-      text: "I do not have more specific hints to provide. Please ensure that the parentheses, braces, and brackets pair correctly, as that is often the problem."
+      text: "I do not have more specific hints to provide. Please ensure that the parentheses, braces, and brackets pair correctly, as that is often the problem.",
     },
   ],
   expected: [

--- a/docs/labs/deserialization.js
+++ b/docs/labs/deserialization.js
@@ -27,31 +27,31 @@ info =
     },
     {
       term: "CONDALL",
-      value: "(COND0 && (COND1 && COND2|COND2 && COND1))"
+      value: "(COND0 && (COND1 && COND2|COND2 && COND1))",
     },
   ],
   hints: [
     {
       absent: "^ const data =\n",
-      text: "The first section should begin with `const data =`"
+      text: "The first section should begin with `const data =`",
     },
     {
       present: "json",
-      text: "the JSON built-in global object is witten in uppercase."
+      text: "the JSON built-in global object is witten in uppercase.",
     },
     {
       absent: String.raw`JSON \. parse
 `,
-      text: "Make a call to `JSON.parse` with the data retrieved, e.g., `JSON.parse(base64Decoded)` should be stored in `data`."
+      text: "Make a call to `JSON.parse` with the data retrieved, e.g., `JSON.parse(base64Decoded)` should be stored in `data`.",
     },
     {
       present: String.raw`\+
 `,
-      text: "You should not have any concatenation (`+`) in the first section."
+      text: "You should not have any concatenation (`+`) in the first section.",
     },
     {
       absent: "; $\n",
-      text: "JavaScript does not require semicolons at the end of a statement, but since the other statements terminate with semicolons, you should also terminate your statement with a semicolon to be consistent."
+      text: "JavaScript does not require semicolons at the end of a statement, but since the other statements terminate with semicolons, you should also terminate your statement with a semicolon to be consistent.",
     },
     {
       absent: String.raw`^ if \(`,
@@ -68,28 +68,28 @@ info =
       absent: String.raw`data \. username
 `,
       index: 1,
-      text: "Check if the data object has a property called username. You can do this by referencing data.username."
+      text: "Check if the data object has a property called username. You can do this by referencing data.username.",
     },
     {
       absent: String.raw`\&\&`,
       index: 1,
-      text: "To combine multiple conditions in JavaScript use &&. This operator means 'and', so both conditions must be true for the entire statement to pass."
+      text: "To combine multiple conditions in JavaScript use &&. This operator means 'and', so both conditions must be true for the entire statement to pass.",
     },
     {
       absent: "typeof",
       index: 1,
-      text: "Use typeof to check the type of the operand's value. You should have `typeof data.username == 'string'` or similar."
+      text: "Use typeof to check the type of the operand's value. You should have `typeof data.username == 'string'` or similar.",
     },
     {
       present: String.raw`typeof data \. username == 'String'
 `,
       index: 1,
-      text: "When using typeof, JavaScript expects \"string\" all lowercase."
+      text: "When using typeof, JavaScript expects \"string\" all lowercase.",
     },
     {
       absent: "length",
       index: 1,
-      text: "check if the length of the string is smaller than 20 characters. Use the expression `data.username.length &lt; 20` to determine this."
+      text: "check if the length of the string is smaller than 20 characters. Use the expression `data.username.length &lt; 20` to determine this.",
     },
     {
       present: String.raw`^ if \(`,

--- a/docs/labs/format-strings.js
+++ b/docs/labs/format-strings.js
@@ -4,24 +4,24 @@ info =
     {
       present: String.raw`def format_event \( user_input
 `,
-      text: "The `user_format` should no longer be used, so we should remove it from the list of parameters being passed into the function being defined by `def`. The first line should read `def format_event(new_event):`"
+      text: "The `user_format` should no longer be used, so we should remove it from the list of parameters being passed into the function being defined by `def`. The first line should read `def format_event(new_event):`",
     },
     {
       present: "user_input",
-      text: "Do not support a user-provided format at all. In this case there is no need for it."
+      text: "Do not support a user-provided format at all. In this case there is no need for it.",
     },
     {
       absent: "event",
-      text: "We want to see `event`, e.g., return '{event.level},...'.format(event=new_event)"
+      text: "We want to see `event`, e.g., return '{event.level},...'.format(event=new_event)",
     },
     {
       present: String.raw`\{0`,
-      text: "For our purposes we want to use named parameters, so do not use `{0}` or similar."
+      text: "For our purposes we want to use named parameters, so do not use `{0}` or similar.",
     },
     {
       absent: String.raw`\'\{event.level\},\{event.message\}\'
 `,
-      text: "The constant text `'{event.level},{event.message}'` should be present."
+      text: "The constant text `'{event.level},{event.message}'` should be present.",
     },
   ],
   expected: [

--- a/docs/labs/free.js
+++ b/docs/labs/free.js
@@ -22,7 +22,7 @@ info =
     },
     {
       absent: "return",
-      text: "This fails to return the result."
+      text: "This fails to return the result.",
     },
     {
       absent: String.raw`\s* [^;]+;[^;]+;[^;]+; \s*`,

--- a/docs/labs/handling-errors.js
+++ b/docs/labs/handling-errors.js
@@ -4,7 +4,7 @@ info =
     {
       index: 0,
       absent: "; $",
-      text: "This code uses the convention of terminating each line with a semicolon; please follow the conventions of the code being modified.\n"
+      text: "This code uses the convention of terminating each line with a semicolon; please follow the conventions of the code being modified.\n",
     },
     {
       index: 0,

--- a/docs/labs/hardcoded.js
+++ b/docs/labs/hardcoded.js
@@ -3,49 +3,49 @@ info =
   hints: [
     {
       absent: String.raw`^ \s* conn = DriverManager \. getConnection \( url \,`,
-      text: "Your answer should start with  `conn = DriverManager.getConnection( url,` just as the initial value did. You might want to use the `Reset` button."
+      text: "Your answer should start with  `conn = DriverManager.getConnection( url,` just as the initial value did. You might want to use the `Reset` button.",
     },
     {
       absent: String.raw`System \. getenv`,
-      text: "Use `System.getenv` to retrieve an environment variable value. For example, use `System.getenv(\"USERNAME\")` to retrieve the username."
+      text: "Use `System.getenv` to retrieve an environment variable value. For example, use `System.getenv(\"USERNAME\")` to retrieve the username.",
     },
     {
       present: String.raw`System \. getenv \( \"admin\" \)`,
-      text: "You need to pass to `System.getenv` the name of an environment variable value, not the result you might get. Do not use constructs like `System.getenv(\"admin\")`. Instead, for example, use `System.getenv(\"USERNAME\")` to retrieve the username."
+      text: "You need to pass to `System.getenv` the name of an environment variable value, not the result you might get. Do not use constructs like `System.getenv(\"admin\")`. Instead, for example, use `System.getenv(\"USERNAME\")` to retrieve the username.",
     },
     {
       absent: String.raw`System \. getenv \( \"PASSWORD\" \)`,
-      text: "Use `System.getenv` to retrieve an environment variable value. For example, use `System.getenv(\"USERNAME\")` to retrieve the username."
+      text: "Use `System.getenv` to retrieve an environment variable value. For example, use `System.getenv(\"USERNAME\")` to retrieve the username.",
     },
     {
       present: "admin",
-      text: "The term 'admin' should not be in your code. You should be retrieving both the username and the password from somewhere else, in this case, from environment variables."
+      text: "The term 'admin' should not be in your code. You should be retrieving both the username and the password from somewhere else, in this case, from environment variables.",
     },
     {
       present: "(system|Getenv|GetEnv)",
-      text: "Java is case-sensitive. You need to use `System.getenv` and not some other variation of uppercase or lowercase."
+      text: "Java is case-sensitive. You need to use `System.getenv` and not some other variation of uppercase or lowercase.",
     },
     {
       absent: String.raw`\; \s* $`,
-      text: "Java statements must end with a semicolon."
+      text: "Java statements must end with a semicolon.",
     },
     {
       absent: String.raw`\) \) \; \s* $`,
-      text: "Double-check your closing parentheses at the end of the statement."
+      text: "Double-check your closing parentheses at the end of the statement.",
     },
     {
       present: String.raw`new\s+String`,
-      text: "You do not need to construct a new string to retrieve an environment variable value."
+      text: "You do not need to construct a new string to retrieve an environment variable value.",
     },
     {
       present: String.raw`^ conn = DriverManager \. getConnection \( url \) \; \s* $`,
-      text: "In some sense this is correct, as long as the url is not hardcoded. However, it's often better if administrators can easily change the username or password separately, and it makes out point clearer. Please provide the username and password and separate values."
+      text: "In some sense this is correct, as long as the url is not hardcoded. However, it's often better if administrators can easily change the username or password separately, and it makes out point clearer. Please provide the username and password and separate values.",
     },
     {
       present: String.raw`^ \s* conn = DriverManager \. getConnection \( url \,
   System \. getenv \( "PASSWORD" \) \,
   System \. getenv \( "USERNAME" \) \) \; \s* $`,
-      text: "The order of parameters is wrong. Provide the url, then the username, then the password. You're providing the url, then the password, then the username, which swaps the second and third parameters."
+      text: "The order of parameters is wrong. Provide the url, then the username, then the password. You're providing the url, then the password, then the username, which swaps the second and third parameters.",
     },
   ],
   expected: [

--- a/docs/labs/redos.js
+++ b/docs/labs/redos.js
@@ -3,73 +3,73 @@ info =
   hints: [
     {
       absent: ", $",
-      text: "This is a parameter, it must end with a comma."
+      text: "This is a parameter, it must end with a comma.",
     },
     {
       absent: String.raw`query \( ["'${BACKQUOTE}]id["'${BACKQUOTE}] \)
 `,
-      text: "Use query() with an 'id' parameter."
+      text: "Use query() with an 'id' parameter.",
     },
     {
       present: String.raw`query \( ["'${BACKQUOTE}]id["'${BACKQUOTE}] \) [^. ]
 `,
-      text: "After query(\"id\") use a period to invoke a verification method."
+      text: "After query(\"id\") use a period to invoke a verification method.",
     },
     {
       present: "(islength|Islength|IsLength|ISLENGTH)\n",
-      text: "JavaScript is case-sensitive. Use isLength instead of the case you have.\n"
+      text: "JavaScript is case-sensitive. Use isLength instead of the case you have.\n",
     },
     {
       absent: "isLength",
-      text: "Limit the maximum length of input strings using isLength()."
+      text: "Limit the maximum length of input strings using isLength().",
     },
     {
       present: String.raw`isLength \( m
 `,
-      text: "You need to pass isLength() an object with the max parameter, e.g., isLength({max: VALUE}).\n"
+      text: "You need to pass isLength() an object with the max parameter, e.g., isLength({max: VALUE}).\n",
     },
     {
       absent: "matches",
-      text: "Use matches()."
+      text: "Use matches().",
     },
     {
       present: String.raw`matches \( /[^^]
 `,
-      text: "Match the whole string - begin the regular expression with ^"
+      text: "Match the whole string - begin the regular expression with ^",
     },
     {
       present: String.raw`matches \( /.*[^$]/
 `,
-      text: "Match the whole string - end the regular expression with $"
+      text: "Match the whole string - end the regular expression with $",
     },
     {
       present: String.raw`matches \( /.*[^$]/
 `,
-      text: "Match the whole string - end the regular expression with $"
+      text: "Match the whole string - end the regular expression with $",
     },
     {
       present: String.raw`matches \( /\^\[A-Z\]
 `,
-      text: "That would match only letters, you need digits as well."
+      text: "That would match only letters, you need digits as well.",
     },
     {
       present: String.raw`matches \( /\^\[a-z\]
 `,
-      text: "That would match only lower case letters, the format requirement is uppercase letters."
+      text: "That would match only lower case letters, the format requirement is uppercase letters.",
     },
     {
       present: String.raw`matches \( /\^\(\[A-Z0-9\]\+\)\+\$ 
 `,
-      text: "Remember to fix the regex, the outer + quantifier causes backtracking by trying to match one or more sequences of one or more uppercase alphanumeric characters."
+      text: "Remember to fix the regex, the outer + quantifier causes backtracking by trying to match one or more sequences of one or more uppercase alphanumeric characters.",
     },
     {
       present: String.raw`matches \( /\^\(\[A-Z0-9\]\+\)\$ 
 `,
-      text: "Remove the grouping, you don’t need the parentheses."
+      text: "Remove the grouping, you don’t need the parentheses.",
     },
     {
       present: String.raw`\[0-9[Aa]-[Zz]\]`,
-      text: "It's conventional to list letters first, so use [A-Z0-9] not [0-9A-Z]"
+      text: "It's conventional to list letters first, so use [A-Z0-9] not [0-9A-Z]",
     },
   ],
   expected: [

--- a/docs/labs/shell-injection.js
+++ b/docs/labs/shell-injection.js
@@ -3,12 +3,12 @@ info =
   hints: [
     {
       absent: String.raw`^[\n\r]*\x20\x20[^\x20]`,
-      text: "Python is an indentation-sensitive language, so your indentation must be consistent. In this case, your line in the first section must start with exactly 2 spaces followed by a non-space.\n"
+      text: "Python is an indentation-sensitive language, so your indentation must be consistent. In this case, your line in the first section must start with exactly 2 spaces followed by a non-space.\n",
     },
     {
       absent: String.raw`^\x20\x20[^\x20]`,
       index: 1,
-      text: "Python is an indentation-sensitive language, so your indentation must be consistent. In this case, your line in the second section must start with exactly 2 spaces followed by a non-space.\n"
+      text: "Python is an indentation-sensitive language, so your indentation must be consistent. In this case, your line in the second section must start with exactly 2 spaces followed by a non-space.\n",
     },
     {
       absent: String.raw`re \. sub`,
@@ -43,11 +43,11 @@ info =
     },
     {
       absent: String.raw`re \. sub \( r`,
-      text: "Python re.sub uses strings to indicate a regex pattern. By convention these strings are usually 'raw' strings, so they have the form `r'PATTERN'`. We would recommend that you use raw strings, in the pattern `re.sub(r'...', ...)` even though raw strings don't make this *specific* example easier.\n"
+      text: "Python re.sub uses strings to indicate a regex pattern. By convention these strings are usually 'raw' strings, so they have the form `r'PATTERN'`. We would recommend that you use raw strings, in the pattern `re.sub(r'...', ...)` even though raw strings don't make this *specific* example easier.\n",
     },
     {
       absent: String.raw`re \. sub \( r['"]`,
-      text: "Python re.sub uses strings to indicate a regex pattern. By convention these strings usually 'raw' strings, so they have the form `r'PATTERN'`. You have the \"r\" but not the following single or double quote character.\n"
+      text: "Python re.sub uses strings to indicate a regex pattern. By convention these strings usually 'raw' strings, so they have the form `r'PATTERN'`. You have the \"r\" but not the following single or double quote character.\n",
     },
     {
       present: String.raw`re \. sub \( r?['"]\(`,
@@ -102,7 +102,7 @@ info =
     {
       absent: "subprocess.run",
       index: 1,
-      text: "Use subprocess.run"
+      text: "Use subprocess.run",
     },
     {
       present: "shell = [Tt]rue",
@@ -162,12 +162,12 @@ info =
     {
       present: String.raw`dir_to_list\"`,
       index: 1,
-      text: "You have a double-quote after `dir_to_list`; you don't want that."
+      text: "You have a double-quote after `dir_to_list`; you don't want that.",
     },
     {
       present: String.raw`clean_dir\"`,
       index: 1,
-      text: "You have a double-quote after `clean_dir`; you don't want that."
+      text: "You have a double-quote after `clean_dir`; you don't want that.",
     },
     {
       present: "dir_to_list",

--- a/docs/labs/sql-injection.js
+++ b/docs/labs/sql-injection.js
@@ -30,29 +30,29 @@ info =
     {
       absent: String.raw`\s* PreparedStatement\s+pstmt = connection \.
     prepareStatement \( QueryString \) \; \s*`,
-      text: "After defining the query string you should create a prepared statement, using the form `PreparedStatement pstmt = connection.prepareStatement(QueryString);`"
+      text: "After defining the query string you should create a prepared statement, using the form `PreparedStatement pstmt = connection.prepareStatement(QueryString);`",
     },
     {
       absent: "search_lastname",
       present: "lastname",
       index: 1,
-      text: "The term `lastname` is the name of the database field to be searched, However, you want to search for a specific value in that field. That value is held in the variable `search_lastname`, not in `lastname`."
+      text: "The term `lastname` is the name of the database field to be searched, However, you want to search for a specific value in that field. That value is held in the variable `search_lastname`, not in `lastname`.",
     },
     {
       absent: String.raw`pstmt \. setString \( 1 , search_lastname \) \;`,
       index: 1,
-      text: "Start the second section with a statement like `pstmt.setString(1, search_lastname);`"
+      text: "Start the second section with a statement like `pstmt.setString(1, search_lastname);`",
     },
     {
       absent: "executeQuery",
       present: "execute",
       index: 1,
-      text: "Use `executeQuery` not `execute` so we can receive and use a potential series of results (a `ResultSet`)."
+      text: "Use `executeQuery` not `execute` so we can receive and use a potential series of results (a `ResultSet`).",
     },
     {
       absent: String.raw`\s* ResultSet\s+results = pstmt \. executeQuery \( \) \; \s*`,
       index: 1,
-      text: "After using `setString` execute the query and place the results in `results`, something like `ResultSet results = pstmt.executeQuery();`"
+      text: "After using `setString` execute the query and place the results in `results`, something like `ResultSet results = pstmt.executeQuery();`",
     },
   ],
   expected: [


### PR DESCRIPTION
A common error when modifying the JavaScript files is forgetting to add a separating comma to the previous line. This is detected when loading (including any tests), but it's still annoying. To reduce the likelihood of this error, add trailing commas to lines of the form "..."