### PR TITLE
Release of The Memory Safety Continuum

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ This is a list of materials (documents, services, and so on) released by the
 * [npm Best Practices Guide](https://github.com/ossf/package-manager-best-practices/blob/main/published/npm.md)
 * [Source Code Management Platform Configuration Best Practices Guide](https://best.openssf.org/SCM-BestPractices/)
 * [Compiler Options Hardening Guide for C and C++](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++)
-* [The Memory Safety Continuum](https://github.com/ossf/Memory-Safety/blob/main/docs/memory-safety-continuum/memory-safety-continuum.md)
+* [The Memory Safety Continuum](https://memorysafety.openssf.org/memory-safety-continuum)
 
 Note: You can also see the larger list of
 [Guides released by the OpenSSF](https://openssf.org/resources/guides/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ This is a list of materials (documents, services, and so on) released by the
 * [npm Best Practices Guide](https://github.com/ossf/package-manager-best-practices/blob/main/published/npm.md)
 * [Source Code Management Platform Configuration Best Practices Guide](https://best.openssf.org/SCM-BestPractices/)
 * [Compiler Options Hardening Guide for C and C++](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++)
+* [The Memory Safety Continuum](https://github.com/ossf/Memory-Safety/blob/main/docs/memory-safety-continuum/memory-safety-continuum.md)
 
 Note: You can also see the larger list of
 [Guides released by the OpenSSF](https://openssf.org/resources/guides/).


### PR DESCRIPTION
This PR adds the Memory Safety Continuum document to the best.openssf.org website.