### PR TITLE
Add "Correctly Using RE" to best.openssf.org index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ This is a list of materials (documents, services, and so on) released by the
 * [npm Best Practices Guide](https://github.com/ossf/package-manager-best-practices/blob/main/published/npm.md)
 * [Source Code Management Platform Configuration Best Practices Guide](https://best.openssf.org/SCM-BestPractices/)
 * [Compiler Options Hardening Guide for C and C++](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++)
+* [Correctly Using Regular Expressions for Secure Input Validation](https://best.openssf.org/Correctly-Using-Regular-Expressions)
 * [The Memory Safety Continuum](https://memorysafety.openssf.org/memory-safety-continuum)
 
 Note: You can also see the larger list of


### PR DESCRIPTION
This commit adds a missing hyperlink.

We previously created the guide
"Correctly Using Regular Expressions for Secure Input Validation" at <https://best.openssf.org/Correctly-Using-Regular-Expressions> and list this guide at <https://openssf.org/resources/guides/>. We forgot to add the guide to the list at best.openssf.org.

This commit adds a link to the guide from
<https://best.openssf.org/>, where it should have been added as well.