### PR TITLE
Embolden website text

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -33,6 +33,13 @@ h1, h2, h3, h4, h5, h6 {
   src: url("/assets/fonts/IBMPlexSans/IBMPlexSans-Regular.ttf");
 }
 
+/* Increase weight so bold/strong are easier to identify as such.
+   Without this, Cairo bold looks like unbolded text.
+*/
+b, strong {
+  font-weight: 700;
+}
+
 /* Number headings */
 
 /*


### PR DESCRIPTION
Boldly go where no one has gone before.

In default body text (Cairo font) it's hard to tell which text is bold and which not.

This increases the font weight, hopefully making bold and strong text easier to identify.