### PR TITLE
Fix the sample code in conversion.html

### DIFF
--- a/docs/labs/conversion.html
+++ b/docs/labs/conversion.html
@@ -48,6 +48,7 @@ unsigned int get_queue(message** messages);
 /* The part of our code which processes messages... */
 <input id="attempt0" type="text" size="60" spellcheck="false" value="int queue_count = 0;" style="background-color: yellow;">
 message* messages = malloc(sizeof(message) * MAX_MESSAGE_COUNT);
+queue_count = get_queue(&messages);
 
 /* Process each message in order */
 for (unsigned int i = 0; i < queue_count; i++) {


### PR DESCRIPTION
Issue : Sample code didn't call get_queue() and queue_count was not set.
Fix : Added the calling of get_queue() to set its return value for queue_count.

Trivial fix but a sample code should be consistent, I think.