### PR TITLE
Add -fsanitize-minimal-runtime and -fsanitize-trap=undefined to UBSan description table

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -1308,6 +1308,7 @@ LSan cannot be used simultaneously with AddressSanitizer (ASan) or ThreadSanitiz
 |:------------------------------------------------------------------------- |:-------------------------:|:--------------------------------------------------------------------------------------------------------------------------------- |
 | <span id="-fsanitize=undefined">`-fsanitize=undefined`</span>             | GCC 4.9.0<br/>Clang 3.3.0 | Enables UndefinedBehaviorSanitizer to detect undefined behavior at run time. Requires `-O1` or higher.                            |
 | <span id="-fsanitize-minimal-runtime">`-fsanitize-minimal-runtime`</span> | Clang 6.0.0               | Enables minimal UBSan runtime rather than Clang's usual libubsan library for using UBSan in production code.                      |
+| <span id="-fsanitize-trap=undefined">`-fsanitize-trap=undefined`</span>   | GCC 13.1.0                | Enables UBSan with reporting through `__builtin_trap` rather than GCC's usual libubsan runtime library. Requires `-O1` or higher. |
 
 UndefinedBehaviorSanitizer (UBSan) is a detector of non-portable or erroneous program constructs which cause behavior which is not clearly defined in the ISO C standard. UBSan provides a large number of sub-options to enable / disable individual checks for different classes of undefined behavior. Consult the GCC[^gcc-instrumentation] and Clang[^clang-ubsan] documentation respectively for up-to-date information on supported sub-options.
 

--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -1304,9 +1304,10 @@ LSan cannot be used simultaneously with AddressSanitizer (ASan) or ThreadSanitiz
 
 ### UndefinedBehaviorSanitizer
 
-| Compiler Flag          |     Supported since      | Description                                                                 |
-|:---------------------- |:---------------------:|:--------------------------------------------------------------------------- |
-| `-fsanitize=undefined`<br/>(requires `-O1` or higher) |   GCC 4.9.0<br/>Clang 3.3.0   | Enables UndefinedBehaviorSanitizer to detect undefined behavior at run time |
+| Compiler Flag                                                             | Supported since           | Description                                                                                                                       |
+|:------------------------------------------------------------------------- |:-------------------------:|:--------------------------------------------------------------------------------------------------------------------------------- |
+| <span id="-fsanitize=undefined">`-fsanitize=undefined`</span>             | GCC 4.9.0<br/>Clang 3.3.0 | Enables UndefinedBehaviorSanitizer to detect undefined behavior at run time. Requires `-O1` or higher.                            |
+| <span id="-fsanitize-minimal-runtime">`-fsanitize-minimal-runtime`</span> | Clang 6.0.0               | Enables minimal UBSan runtime rather than Clang's usual libubsan library for using UBSan in production code.                      |
 
 UndefinedBehaviorSanitizer (UBSan) is a detector of non-portable or erroneous program constructs which cause behavior which is not clearly defined in the ISO C standard. UBSan provides a large number of sub-options to enable / disable individual checks for different classes of undefined behavior. Consult the GCC[^gcc-instrumentation] and Clang[^clang-ubsan] documentation respectively for up-to-date information on supported sub-options.
 


### PR DESCRIPTION
Fixes #326 together with #931.