### PR TITLE
CWE-1095: show that list modification is dangerous

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/CWE-710/CWE-1095/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-710/CWE-1095/README.md
@@ -6,20 +6,27 @@ In-place modification of mutable types such as `list`, `dict`, or `set` that are
 
 ## Non-Compliant Code Example (List)
 
-This `noncompliant01.py` example will successfully remove the Bob from `userlist` but this modifies the original list `userlist` and is not recommended.
+This `noncompliant01.py` example will remove only one name that starts with `B` despite trying to remove them all without any exception raised:
 
 [*noncompliant01.py:*](noncompliant01.py)
 
 ```py
 """ Non-compliant Code Example """
-userlist = ['Alice', 'Bob', 'Charlie']
+userlist = ['Alice', 'Bob', 'Bill', 'Charlie']
 print(f'Unmodified list: {userlist}')
 
 for user in userlist:
-    if user == 'Bob':
+    if user.startswith('B'):
         userlist.remove(user)
 
 print(f'Modified list: {userlist}')
+```
+
+Output from above noncompliant01.py:
+
+```bash
+Unmodified list: ['Alice', 'Bob', 'Bill', 'Charlie']
+Modified list: ['Alice', 'Bill', 'Charlie']
 ```
 
 ## Non-Compliant Code Example (Dict)
@@ -63,12 +70,12 @@ The `compliant01.py` solution demonstrates both strategies. The first example cr
 
 ```py
 """ Compliant Code Example """
-userlist = ['Alice', 'Bob', 'Charlie']
+userlist = ['Alice', 'Bob', 'Bill', 'Charlie']
 print(f'Unmodified list: {userlist}')
  
 # Create a copy
 for user in userlist.copy():
-    if user == 'Bob':
+    if user.startswith('B'):
         userlist.remove(user)
  
 print(f'Modified list: {userlist}')
@@ -80,7 +87,7 @@ print(f'Unmodified list: {userlist2}')
 # Create new list
 activeusers = []
 for user in userlist2:
-    if user != 'Bob':
+    if user.startswith('B'):
         activeusers.append(user)
 print(f'New list: {activeusers}')
 ```

--- a/docs/Secure-Coding-Guide-for-Python/CWE-710/CWE-1095/compliant01.py
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-710/CWE-1095/compliant01.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: OpenSSF project contributors
 # SPDX-License-Identifier: MIT
 """ Compliant Code Example """
-userlist = ['Alice', 'Bob', 'Charlie']
+userlist = ['Alice', 'Bob', 'Bill', 'Charlie']
 print(f'Unmodified list: {userlist}')
 
 # Create a copy
 for user in userlist.copy():
-    if user == 'Bob':
+    if user.startswith('B'):
         userlist.remove(user)
 
 print(f'Modified list: {userlist}')
@@ -18,6 +18,6 @@ print(f'Unmodified list: {userlist2}')
 # Create new list
 activeusers = []
 for user in userlist2:
-    if user != 'Bob':
+    if not user.startswith('B'):
         activeusers.append(user)
 print(f'New list: {activeusers}')

--- a/docs/Secure-Coding-Guide-for-Python/CWE-710/CWE-1095/noncompliant01.py
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-710/CWE-1095/noncompliant01.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: OpenSSF project contributors
 # SPDX-License-Identifier: MIT
 """ Non-compliant Code Example """
-userlist = ['Alice', 'Bob', 'Charlie']
+userlist = ['Alice', 'Bob', 'Bill', 'Charlie']
 print(f'Unmodified list: {userlist}')
 
 for user in userlist:
-    if user == 'Bob':
+    if user.startswith('B'):
         userlist.remove(user)
 
 print(f'Modified list: {userlist}')


### PR DESCRIPTION
Before this commit the wording was that modifying list works but is not recommended.

But it works as long as no two consecutive elements are deleted, otherwise part of elements is not checked at all without any exceptions raised.

Changed README.md, compliant01.py and noncompliant01.py to demonstrate that.