### PR TITLE
Tidying up Compiler Annotations Guide code examples

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Annotations-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Annotations-for-C-and-C++.md
@@ -104,8 +104,6 @@ void * my_malloc(size_t size) [[gnu::malloc]] [[gnu::malloc(my_free, 1)]];
 In `__attribute__` keyword syntax:
 
 ~~~c
-void my_free(void *ptr);
-
 // Denotes that my_malloc will return with a dynamically allocated piece of memory which must be freed using my_free.
 void *my_malloc(size_t size) __attribute__ ((malloc, malloc (my_free, 1))) { … }
 ~~~
@@ -365,13 +363,6 @@ In C++11 / C23 attribute syntax:
 ~~~c
 // Denotes that fatal will never return
 void fatal () [[noreturn]];
-          
-void
-fatal (...)
-{
-    ... /* Print error message. */ ...
-    exit (1);
-}
 ~~~
 
 In `__attribute__` keyword syntax:

--- a/docs/Compiler-Hardening-Guides/Compiler-Annotations-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Annotations-for-C-and-C++.md
@@ -107,7 +107,7 @@ In `__attribute__` keyword syntax:
 void my_free(void *ptr);
 
 // Denotes that my_malloc will return with a dynamically allocated piece of memory which must be freed using my_free.
-void *my_malloc(size_t size) __attribute__ ((malloc, malloc (my_free, 1)));
+void *my_malloc(size_t size) __attribute__ ((malloc, malloc (my_free, 1))) { … }
 ~~~
 
 Note that to benefit both from the associated optimizations and improved detection of memory errors functions should be marked with _both_ the form of the attribute without arguments and the form of the attribute with one or two arguments. [[Extended example at Compiler Explorer](https://godbolt.org/z/bc97ahbnd)]


### PR DESCRIPTION
- Fix function definition example to show definition instead of declaration
- Remove redundant code from examples
