### PR TITLE
pySCG: adding 117 as part of #531

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
@@ -1,16 +1,18 @@
 # CWE-117: Improper Output Neutralization for Logs
 
-Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of XSS attacks when logs are viewed in vulnerable web applications.
+Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of `XSS` attacks when logs are viewed in vulnerable web applications.
 
-Attackers can exploit this weakness by submitting strings containing CRLF (Carriage Return Line Feed) sequences that create fake log entries. For instance, an attacker authenticating with a crafted username can make failed login attempts appear successful in audit logs, potentially framing innocent users or hiding malicious activity.
+Attackers can exploit this weakness by submitting strings containing `CRLF` (Carriage Return Line Feed) sequences that create fake log entries. For instance, an attacker authenticating with a crafted username can make failed login attempts appear successful in audit logs, potentially framing innocent users or hiding malicious activity.
 
-This vulnerability is classified as **CWE-117: Improper Output Neutralization for Logs** [cwe117]. It occurs when CRLF sequences are not properly neutralized in log output, which is a specific instance of the broader **CWE-93: Improper Neutralization of CRLF Sequences** [cwe93] weakness. Attackers exploit this using the **CAPEC-93: Log Injection-Tampering-Forging** [capec93] attack pattern.
+This vulnerability is classified as **CWE-117: Improper Output Neutralization for Logs** [[CWE-117](https://cwe.mitre.org/data/definitions/117.html)]. It occurs when `CRLF` sequences are not properly neutralized in log output, which is a specific instance of the broader **CWE-93: Improper Neutralization of CRLF Sequences** [[CWE-93](https://cwe.mitre.org/data/definitions/93.html)] weakness. Attackers exploit this using the **CAPEC-93: Log Injection-Tampering-Forging** [[CAPEC-93](https://capec.mitre.org/data/definitions/93.html)] attack pattern.
 
-The OWASP Top 10 lists “Security Logging and Monitoring Failures” as a critical security risk, emphasizing that log data must be encoded correctly to prevent injections.
+The OWASP Top 10 [[OWASP](https://owasp.org/www-project-top-ten/)]lists “Security Logging and Monitoring Failures” as a critical security risk, emphasizing that log data must be encoded correctly to prevent injections.
 
 ## Noncompliant Code Example
 
 This example demonstrates how raw user input written to logs enables injection attacks:
+
+_[noncompliant01.py](noncompliant01.py):_
 
 ```python
 """ Non-compliant Code Example """
@@ -26,7 +28,7 @@ def log_authentication_failed(user):
 log_authentication_failed("guest'\nWARNING:root:User login failed for: 'administrator")
 ```
 
-The output demonstrates successful log injection:
+**Expample output of noncompliant01.py:**
 
 ```bash
 WARNING:root:User login failed for: 'guest'
@@ -37,7 +39,9 @@ The attacker's input creates what appears to be a legitimate log entry showing a
 
 ## Compliant Solution
 
-The `compliant01.py` solution uses a strict allow-list for usernames and returns early on any mismatch, so CR/LF or other disallowed characters never reach the logger; for rejected attempts it logs a safe one-line summary with `%r` (escaped newlines), preventing forged secondary log lines. In short: validate upfront and neutralize what you do record.
+The `compliant01.py` solution uses a strict allow-list for usernames and returns early on any mismatch, so `CR/LF` or other disallowed characters never reach the logger; for rejected attempts it logs a safe one-line summary with `%r` (escaped newlines), preventing forged secondary log lines. In short: validate upfront and neutralize what you do record.
+
+_[compliant01.py](compliant01.py):_
 
 ```python
 """ Compliant Code Example """
@@ -75,6 +79,8 @@ log_authentication_failed("guest'\nWARNING:root:User login failed for: 'administ
 ```
 
 The following output shows that a warning is logged, and the input is sanitized before logging.
+
+**Example compliant01.py output:**
 
 ```bash
 WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User login failed for: 'administrator"
@@ -121,26 +127,38 @@ WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User
 
 ## Related Guidelines
 
-- **CWE-117**: Improper Output Neutralization for Logs [cwe117]
-- **CWE-93**: Improper Neutralization of CRLF Sequences ('CRLF Injection') [cwe93]
-- **CWE-113**: Improper Neutralization of CRLF Sequences in HTTP Headers [cwe113]
-- **CAPEC-93**: Log Injection-Tampering-Forging [capec93]
-- **OWASP Top 10 2021**: A09 - Security Logging and Monitoring Failures [owasp_top10_2021]
-- **OWASP ASVS 4.0**: V7.1 Log Content Requirements [owasp_asvs]
-- **ISO/IEC TR 24772:2013**: Injection [RST] [iso24772]
-- **NIST SP 800-92**: Guide to Computer Security Log Management [nist80092]
+<table>
+    <tr>
+        <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
+        <td>Pillar: <a href="https://cwe.mitre.org/data/definitions/707.html"> CWE-707: Improper Neutralization</a></td>
+    </tr>
+    <tr>
+        <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
+        <td>Base: <a href="https://cwe.mitre.org/data/definitions/117.html">CWE-117: Improper Output Neutralization for Log</a></td>
+    </tr>
+    <tr>
+        <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
+        <td>Base: <a href="https://cwe.mitre.org/data/definitions/93.html">CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection')</a></td>
+    </tr>
+    <tr>
+        <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
+        <td>Variant: <a href="https://cwe.mitre.org/data/definitions/113.html">CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')</a></td>
+    </tr>
+    <tr>
+        <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
+        <td>Detailed: <a href="https://capec.mitre.org/data/definitions/93.html">CAPEC-93: Log Injection-Tampering-Forging</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://csrc.nist.gov/">NIST SP 800-92</a></td>
+        <td><a href="https://csrc.nist.gov/pubs/sp/800/92/final">2006 Guide to Computer Security Log Management</a></td>
+    </tr>
+</table>
 
 ## Bibliography
 
-<ul>
-  <li>[cwe117] MITRE. “CWE-117: Improper Output Neutralization for Logs” [online]. Available from: <a href="https://cwe.mitre.org/data/definitions/117.html">https://cwe.mitre.org/data/definitions/117.html</a>. Accessed 23 September 2025.</li>
-  <li>[cwe93] MITRE. “CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection')” [online]. Available from: <a href="https://cwe.mitre.org/data/definitions/93.html">https://cwe.mitre.org/data/definitions/93.html</a>. Accessed 23 September 2025.</li>
-  <li>[cwe113] MITRE. “CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers” [online]. Available from: <a href="https://cwe.mitre.org/data/definitions/113.html">https://cwe.mitre.org/data/definitions/113.html</a>. Accessed 23 September 2025.</li>
-  <li>[capec93] MITRE. “CAPEC-93: Log Injection‑Tampering‑Forging” [online]. Available from: <a href="https://capec.mitre.org/data/definitions/93.html">https://capec.mitre.org/data/definitions/93.html</a>. Accessed 23 September 2025.</li>
-  <li>[nist80092] Kent, K.; Souppaya, M. “NIST Special Publication 800‑92: Guide to Computer Security Log Management” [online]. Available from: <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-92.pdf">https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-92.pdf</a>. Accessed 23 September 2025.</li>
-  <li>[owasp_asvs] OWASP. “Application Security Verification Standard 4.x” [online]. Available from: <a href="https://owasp.org/www-project-application-security-verification-standard/">https://owasp.org/www-project-application-security-verification-standard/</a>. Accessed 23 September 2025.</li>
-  <li>[owasp_top10_2021] OWASP. “OWASP Top 10 — 2021: A09 Security Logging and Monitoring Failures” [online]. Available from: <a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/</a>. Accessed 23 September 2025.</li>
-  <li>[codeql] GitHub. “Log Injection — CodeQL query help (Python)” [online]. Available from: <a href="https://codeql.github.com/codeql-query-help/python/py-log-injection/">https://codeql.github.com/codeql-query-help/python/py-log-injection/</a>. Accessed 23 September 2025.</li>
-  <li>[veracode] Veracode. “How to Fix CWE‑117 — Improper Output Neutralization for Logs” [online]. Available from: <a href="https://community.veracode.com/s/article/How-to-Fix-CWE-117-Improper-Output-Neutralization-for-Logs">https://community.veracode.com/s/article/How-to-Fix-CWE-117-Improper-Output-Neutralization-for-Logs</a>. Accessed 23 September 2025.</li>
-  <li>[iso24772] ISO/IEC. “TR 24772:2013 — Programming languages — Guidance to avoiding vulnerabilities in programming languages through language selection and use (Withdrawn)” [online]. Available from: <a href="https://www.iso.org/standard/61457.html">https://www.iso.org/standard/61457.html</a>. Accessed 23 September 2025.</li>
-</ul>
+<table>
+    <tr>
+        <td>[OWASP ASVS 4.0]</td>
+        <td>Python Software Foundation. (2024). concurrent.futures — Launching parallel tasks [online]. Available from: <a href="https://docs.python.org/3.10/library/concurrent.futures.html">https://docs.python.org/3.10/library/concurrent.futures.html</a>,  [Accessed 18 September 2025]</td>
+    </tr>
+</table>

--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
@@ -1,6 +1,6 @@
 # CWE-117: Improper Output Neutralization for Logs
 
-Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of XSS attacks when logs are viewed in vulnerable web applications.
+Ensure all untrusted data is properly neutralized or sanitized before writing to application logs. Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of XSS attacks when logs are viewed in vulnerable web applications.
 
 Attackers can exploit this weakness (see [*Attacks on Logs*](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#attacks-on-logs) [[OWASP 2025]](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#attacks-on-logs)) by submitting strings containing CRLF sequences that create fake log entries.
 

--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
@@ -2,17 +2,19 @@
 
 Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of XSS attacks when logs are viewed in vulnerable web applications.
 
+Attackers can exploit this weakness (see [*Attacks on Logs*](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#attacks-on-logs) [[OWASP 2025]](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#attacks-on-logs)) by submitting strings containing CRLF sequences that create fake log entries.
+
 Attackers can exploit this weakness by submitting strings containing Carriage Return Line Feed (CRLF) sequences that create fake log entries. For instance, an attacker authenticating with a crafted username can make failed login attempts appear successful in audit logs, potentially framing innocent users or hiding malicious activity.
 
 This vulnerability is classified as **CWE-117: Improper Output Neutralization for Logs** [[CWE-117](https://cwe.mitre.org/data/definitions/117.html)]. It occurs when CRLF sequences are not properly neutralized in log output, which is a specific instance of the broader **CWE-93: Improper Neutralization of CRLF Sequences** [[CWE-93](https://cwe.mitre.org/data/definitions/93.html)] weakness. Attackers exploit this using the **CAPEC-93: Log Injection-Tampering-Forging** [[CAPEC-93](https://capec.mitre.org/data/definitions/93.html)] attack pattern.
 
-The OWASP Top 10 [[OWASP A09:2021](https://owasp.org/www-project-top-ten/)]lists “Security Logging and Monitoring Failures” as a critical security risk, emphasizing that log data must be encoded correctly to prevent injections.
+The OWASP Top 10 [[OWASP A09:2021](https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/)] lists “Security Logging and Monitoring Failures” as a critical security risk.
 
 ## Noncompliant Code Example
 
 This example demonstrates how raw user input written to logs enables injection attacks:
 
-_[noncompliant01.py](noncompliant01.py):_
+*[noncompliant01.py](noncompliant01.py):*
 
 ```python
 """ Non-compliant Code Example """
@@ -39,9 +41,11 @@ The attacker's input creates what appears to be a legitimate log entry showing a
 
 ## Compliant Solution
 
+As per the OWASP Logging Cheat Sheet [[OWASP 2025]](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html) section on ["Event collection"](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#event-collection), applications should sanitize event data to prevent log injection and encode data correctly for the logged format.
+
 The `compliant01.py` solution uses a strict allow-list for usernames and returns early on any mismatch, so `CR/LF` or other disallowed characters never reach the logger; for rejected attempts it logs a safe one-line summary with `%r` (escaped newlines), preventing forged secondary log lines. In short: validate upfront and neutralize what you do record.
 
-_[compliant01.py](compliant01.py):_
+*[compliant01.py](compliant01.py):*
 
 ```python
 """ Compliant Code Example """
@@ -105,12 +109,6 @@ WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User
       <td></td>
     </tr>
     <tr>
-      <td>PyLint</td>
-      <td>2.17</td>
-      <td>Not Available</td>
-      <td></td>
-    </tr>
-    <tr>
       <td>CodeQL</td>
       <td>Latest</td>
       <td><a href="https://codeql.github.com/codeql-query-help/python/py-log-injection/">py-log-injection</a></td>
@@ -130,49 +128,50 @@ WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User
 <table>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Pillar: <a href="https://cwe.mitre.org/data/definitions/707.html"> CWE-707: Improper Neutralization [CWE-707] </a></td>
+        <td>Pillar: <a href="https://cwe.mitre.org/data/definitions/707.html"> CWE-707: Improper Neutralization</a></td>
     </tr>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Base: <a href="https://cwe.mitre.org/data/definitions/117.html">CWE-117: Improper Output Neutralization for Log </a>[CWE-117]</td>
+        <td>Base: <a href="https://cwe.mitre.org/data/definitions/117.html">CWE-117: Improper Output Neutralization for Log </a></td>
     </tr>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Base: <a href="https://cwe.mitre.org/data/definitions/93.html">CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection') </a>[CWE-93]</td>
+        <td>Base: <a href="https://cwe.mitre.org/data/definitions/93.html">CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection') </a></td>
     </tr>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Variant: <a href="https://cwe.mitre.org/data/definitions/113.html">CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting') </a>[CWE-113]</td>
+        <td>Variant: <a href="https://cwe.mitre.org/data/definitions/113.html">CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting') </a></td>
     </tr>
     <tr>
         <td><a href="http://capec.mitre.org/">MITRE CAPEC</a></td>
-        <td>Detailed: <a href="https://capec.mitre.org/data/definitions/93.html">CAPEC-93: Log Injection-Tampering-Forging </a>[CAPEC-93]</td>
+        <td>Detailed: <a href="https://capec.mitre.org/data/definitions/93.html">CAPEC-93: Log Injection-Tampering-Forging </a></td>
     </tr>
     <tr>
         <td><a href="https://owasp.org/Top10/">OWASP Top 10</a></td>
-        <td><a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">A09:2021 – Security Logging and Monitoring Failures </a>[OWASP A09:2021]</td>
+        <td><a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">A09:2021 – Security Logging and Monitoring Failures </a></td>
     </tr>
     <tr>
         <td><a href="https://owasp.org/">OWASP ASVS 4.0</a></td>
-        <td><a href="https://owasp.org/www-project-application-security-verification-standard/">OWASP Application Security Verification Standard (ASVS) </a>[OWASP ASVS 4.0]</td>
+        <td><a href="https://owasp.org/www-project-application-security-verification-standard/">OWASP Application Security Verification Standard (ASVS) </a>. See "V16 Security Logging and Error Handling".
+</td>
+    <tr>
+        <td><a href="https://cheatsheetseries.owasp.org/index.html">OWASP Cheat Sheet Series</a></td>
+        <td><a href="https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html">OWASP Logging Cheat Sheet</a></td>
+    </tr>
     </tr>
     <tr>
         <td>ISO/IEC TR 24772:2013</td>
-        <td><a href="https://www.iso.org/standard/61457.html">ISO/IEC TR 24772:2013 Information technology — Programming languages — Guidance to avoiding vulnerabilities in programming languages through language selection and use </a>[ISO 24772:2013]</td>
+        <td><a href="https://www.iso.org/standard/61457.html">ISO/IEC TR 24772:2013 Information technology — Programming languages — Guidance to avoiding vulnerabilities in programming languages through language selection and use </a></td>
     </tr>
     <tr>
         <td>NIST SP 800-92</td>
-        <td><a href="https://csrc.nist.gov/pubs/sp/800/92/final">NIST SP 800-92 Guide to Computer Security Log Management </a>[NIST SP 800-92]</td>
+        <td><a href="https://csrc.nist.gov/pubs/sp/800/92/final">NIST SP 800-92 Guide to Computer Security Log Management </a></td>
     </tr>
 </table>
 
 ## Bibliography
 
 <table>
-    <tr>
-        <td>[CWE-707]</a></td>
-        <td>CWE-707: Improper Neutralization [online]. Available from <a href="https://cwe.mitre.org/data/definitions/707.html">https://cwe.mitre.org/data/definitions/707.html</a>, [Accessed 24 September 2025]</td>
-    </tr>
     <tr>
         <td>[CWE-117]</a></td>
         <td>CWE-117: Improper Output Neutralization for Log [online]. Available from <a href="https://cwe.mitre.org/data/definitions/117.html">https://cwe.mitre.org/data/definitions/117.html</a>, [Accessed 24 September 2025]</td>
@@ -194,16 +193,7 @@ WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User
         <td>A09:2021 – Security Logging and Monitoring Failures [online]. Available from:<a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/</a>, [Accessed 24 September 2025]</td>
     </tr>
     <tr>
-        <td>[OWASP ASVS 4.0]</td>
-        <td>OWASP Application Security Verification Standard (ASVS) [online]. Available from: <a href="https://owasp.org/www-project-application-security-verification-standard/">https://owasp.org/www-project-application-security-verification-standard/</a>, [Accessed 24 September 2025]</td>
-    </tr>
-    <tr>
-        <td>[ISO 24772:2013]</td>
-        <td>ISO/IEC TR 24772:2013 Information technology — Programming languages — Guidance to avoiding vulnerabilities in programming languages through language selection and use [online]. Available from:
-        <a href="https://www.iso.org/standard/61457.html">https://www.iso.org/standard/61457.html</a>, [Accessed 24 September 2025]</td>
-    </tr>
-    <tr>
-        <td>[NIST SP 800-92]</td>
-        <td>NIST SP 800-92 Guide to Computer Security Log Management [online]. Available from:<a href="https://csrc.nist.gov/pubs/sp/800/92/final">https://csrc.nist.gov/pubs/sp/800/92/final</a>, [Accessed 24 September 2025]</td>
+        <td>[OWASP 2025]</td>
+        <td>OWASP Cheat Sheet Series: Logging Cheat Sheet [online]. Available from: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html">https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html</a> (see “Event collection” and “Attacks on Logs”). [Accessed 24 September 2025]</td>
     </tr>
 </table>

--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
@@ -1,12 +1,12 @@
 # CWE-117: Improper Output Neutralization for Logs
 
-Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of `XSS` attacks when logs are viewed in vulnerable web applications.
+Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of XSS attacks when logs are viewed in vulnerable web applications.
 
-Attackers can exploit this weakness by submitting strings containing `CRLF` (Carriage Return Line Feed) sequences that create fake log entries. For instance, an attacker authenticating with a crafted username can make failed login attempts appear successful in audit logs, potentially framing innocent users or hiding malicious activity.
+Attackers can exploit this weakness by submitting strings containing Carriage Return Line Feed (CRLF) sequences that create fake log entries. For instance, an attacker authenticating with a crafted username can make failed login attempts appear successful in audit logs, potentially framing innocent users or hiding malicious activity.
 
-This vulnerability is classified as **CWE-117: Improper Output Neutralization for Logs** [[CWE-117](https://cwe.mitre.org/data/definitions/117.html)]. It occurs when `CRLF` sequences are not properly neutralized in log output, which is a specific instance of the broader **CWE-93: Improper Neutralization of CRLF Sequences** [[CWE-93](https://cwe.mitre.org/data/definitions/93.html)] weakness. Attackers exploit this using the **CAPEC-93: Log Injection-Tampering-Forging** [[CAPEC-93](https://capec.mitre.org/data/definitions/93.html)] attack pattern.
+This vulnerability is classified as **CWE-117: Improper Output Neutralization for Logs** [[CWE-117](https://cwe.mitre.org/data/definitions/117.html)]. It occurs when CRLF sequences are not properly neutralized in log output, which is a specific instance of the broader **CWE-93: Improper Neutralization of CRLF Sequences** [[CWE-93](https://cwe.mitre.org/data/definitions/93.html)] weakness. Attackers exploit this using the **CAPEC-93: Log Injection-Tampering-Forging** [[CAPEC-93](https://capec.mitre.org/data/definitions/93.html)] attack pattern.
 
-The OWASP Top 10 [[OWASP](https://owasp.org/www-project-top-ten/)]lists “Security Logging and Monitoring Failures” as a critical security risk, emphasizing that log data must be encoded correctly to prevent injections.
+The OWASP Top 10 [[OWASP A09:2021](https://owasp.org/www-project-top-ten/)]lists “Security Logging and Monitoring Failures” as a critical security risk, emphasizing that log data must be encoded correctly to prevent injections.
 
 ## Noncompliant Code Example
 
@@ -28,7 +28,7 @@ def log_authentication_failed(user):
 log_authentication_failed("guest'\nWARNING:root:User login failed for: 'administrator")
 ```
 
-**Expample output of noncompliant01.py:**
+**Output of `noncompliant01.py`:**
 
 ```bash
 WARNING:root:User login failed for: 'guest'
@@ -130,27 +130,39 @@ WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User
 <table>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Pillar: <a href="https://cwe.mitre.org/data/definitions/707.html"> CWE-707: Improper Neutralization</a></td>
+        <td>Pillar: <a href="https://cwe.mitre.org/data/definitions/707.html"> CWE-707: Improper Neutralization [CWE-707] </a></td>
     </tr>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Base: <a href="https://cwe.mitre.org/data/definitions/117.html">CWE-117: Improper Output Neutralization for Log</a></td>
+        <td>Base: <a href="https://cwe.mitre.org/data/definitions/117.html">CWE-117: Improper Output Neutralization for Log </a>[CWE-117]</td>
     </tr>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Base: <a href="https://cwe.mitre.org/data/definitions/93.html">CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection')</a></td>
+        <td>Base: <a href="https://cwe.mitre.org/data/definitions/93.html">CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection') </a>[CWE-93]</td>
     </tr>
     <tr>
         <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Variant: <a href="https://cwe.mitre.org/data/definitions/113.html">CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')</a></td>
+        <td>Variant: <a href="https://cwe.mitre.org/data/definitions/113.html">CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting') </a>[CWE-113]</td>
     </tr>
     <tr>
-        <td><a href="http://cwe.mitre.org/">MITRE CWE</a></td>
-        <td>Detailed: <a href="https://capec.mitre.org/data/definitions/93.html">CAPEC-93: Log Injection-Tampering-Forging</a></td>
+        <td><a href="http://capec.mitre.org/">MITRE CAPEC</a></td>
+        <td>Detailed: <a href="https://capec.mitre.org/data/definitions/93.html">CAPEC-93: Log Injection-Tampering-Forging </a>[CAPEC-93]</td>
     </tr>
     <tr>
-        <td><a href="https://csrc.nist.gov/">NIST SP 800-92</a></td>
-        <td><a href="https://csrc.nist.gov/pubs/sp/800/92/final">2006 Guide to Computer Security Log Management</a></td>
+        <td><a href="https://owasp.org/Top10/">OWASP Top 10</a></td>
+        <td><a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">A09:2021 – Security Logging and Monitoring Failures </a>[OWASP A09:2021]</td>
+    </tr>
+    <tr>
+        <td><a href="https://owasp.org/">OWASP ASVS 4.0</a></td>
+        <td><a href="https://owasp.org/www-project-application-security-verification-standard/">OWASP Application Security Verification Standard (ASVS) </a>[OWASP ASVS 4.0]</td>
+    </tr>
+    <tr>
+        <td>ISO/IEC TR 24772:2013</td>
+        <td><a href="https://www.iso.org/standard/61457.html">ISO/IEC TR 24772:2013 Information technology — Programming languages — Guidance to avoiding vulnerabilities in programming languages through language selection and use </a>[ISO 24772:2013]</td>
+    </tr>
+    <tr>
+        <td>NIST SP 800-92</td>
+        <td><a href="https://csrc.nist.gov/pubs/sp/800/92/final">NIST SP 800-92 Guide to Computer Security Log Management </a>[NIST SP 800-92]</td>
     </tr>
 </table>
 
@@ -158,7 +170,40 @@ WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User
 
 <table>
     <tr>
+        <td>[CWE-707]</a></td>
+        <td>CWE-707: Improper Neutralization [online]. Available from <a href="https://cwe.mitre.org/data/definitions/707.html">https://cwe.mitre.org/data/definitions/707.html</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
+        <td>[CWE-117]</a></td>
+        <td>CWE-117: Improper Output Neutralization for Log [online]. Available from <a href="https://cwe.mitre.org/data/definitions/117.html">https://cwe.mitre.org/data/definitions/117.html</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
+        <td>[CWE-93]</a></td>
+        <td>CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection') [online]. Available from: <a href="https://cwe.mitre.org/data/definitions/93.html">https://cwe.mitre.org/data/definitions/93.html</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
+        <td>[CWE-113]</a></td>
+        <td>CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')<a href="https://cwe.mitre.org/data/definitions/113.html">https://cwe.mitre.org/data/definitions/113.html</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
+        <td>[CAPEC-93]</td>
+        <td>CAPEC-93: Log Injection-Tampering-Forging [online]. Available from: <a href="https://capec.mitre.org/data/definitions/93.html">https://capec.mitre.org/data/definitions/93.html</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
+        <td>[OWASP A09:2021]</td>
+        <td>A09:2021 – Security Logging and Monitoring Failures [online]. Available from:<a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
         <td>[OWASP ASVS 4.0]</td>
-        <td>Python Software Foundation. (2024). concurrent.futures — Launching parallel tasks [online]. Available from: <a href="https://docs.python.org/3.10/library/concurrent.futures.html">https://docs.python.org/3.10/library/concurrent.futures.html</a>,  [Accessed 18 September 2025]</td>
+        <td>OWASP Application Security Verification Standard (ASVS) [online]. Available from: <a href="https://owasp.org/www-project-application-security-verification-standard/">https://owasp.org/www-project-application-security-verification-standard/</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
+        <td>[ISO 24772:2013]</td>
+        <td>ISO/IEC TR 24772:2013 Information technology — Programming languages — Guidance to avoiding vulnerabilities in programming languages through language selection and use [online]. Available from:
+        <a href="https://www.iso.org/standard/61457.html">https://www.iso.org/standard/61457.html</a>, [Accessed 24 September 2025]</td>
+    </tr>
+    <tr>
+        <td>[NIST SP 800-92]</td>
+        <td>NIST SP 800-92 Guide to Computer Security Log Management [online]. Available from:<a href="https://csrc.nist.gov/pubs/sp/800/92/final">https://csrc.nist.gov/pubs/sp/800/92/final</a>, [Accessed 24 September 2025]</td>
     </tr>
 </table>

--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/README.md
@@ -1,0 +1,146 @@
+# CWE-117: Improper Output Neutralization for Logs
+
+Log injection occurs when untrusted data is written to application logs without proper neutralization, allowing attackers to forge log entries or inject malicious content. Attackers can inject fake log records or hide real ones by inserting newline sequences (`\r` or `\n`), misleading auditors and incident-response teams. This vulnerability can also enable injection of XSS attacks when logs are viewed in vulnerable web applications.
+
+Attackers can exploit this weakness by submitting strings containing CRLF (Carriage Return Line Feed) sequences that create fake log entries. For instance, an attacker authenticating with a crafted username can make failed login attempts appear successful in audit logs, potentially framing innocent users or hiding malicious activity.
+
+This vulnerability is classified as **CWE-117: Improper Output Neutralization for Logs** [cwe117]. It occurs when CRLF sequences are not properly neutralized in log output, which is a specific instance of the broader **CWE-93: Improper Neutralization of CRLF Sequences** [cwe93] weakness. Attackers exploit this using the **CAPEC-93: Log Injection-Tampering-Forging** [capec93] attack pattern.
+
+The OWASP Top 10 lists “Security Logging and Monitoring Failures” as a critical security risk, emphasizing that log data must be encoded correctly to prevent injections.
+
+## Noncompliant Code Example
+
+This example demonstrates how raw user input written to logs enables injection attacks:
+
+```python
+""" Non-compliant Code Example """
+import logging
+
+def log_authentication_failed(user):
+    """Simplified audit logging missing RFC 5424 details"""
+    logging.warning("User login failed for: '%s'", user)
+
+#####################
+# attempting to exploit above code example
+#####################
+log_authentication_failed("guest'\nWARNING:root:User login failed for: 'administrator")
+```
+
+The output demonstrates successful log injection:
+
+```bash
+WARNING:root:User login failed for: 'guest'
+WARNING:root:User login failed for: 'administrator'
+```
+
+The attacker's input creates what appears to be a legitimate log entry showing a login failure for user `administrator`.
+
+## Compliant Solution
+
+The `compliant01.py` solution uses a strict allow-list for usernames and returns early on any mismatch, so CR/LF or other disallowed characters never reach the logger; for rejected attempts it logs a safe one-line summary with `%r` (escaped newlines), preventing forged secondary log lines. In short: validate upfront and neutralize what you do record.
+
+```python
+""" Compliant Code Example """
+
+import logging
+import re
+
+# Allow only ASCII letters, digits, underscore, dot, and hyphen; max 64 chars
+_ALLOWED_USER = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+def is_allowed_username(user: str) -> bool:
+    """Return True if username matches the strict allow-list."""
+    return bool(_ALLOWED_USER.fullmatch(user))
+
+
+def log_authentication_failed(user):
+    """Simplified audit logging (example)"""
+    if not is_allowed_username(user):
+        # Safe summary: %r escapes CR/LF so the log remains one line
+        logging.warning("Rejected login attempt: invalid username=%r", user)
+        return
+    logging.warning("User login failed for: '%s'", user)
+
+
+#####################
+# attempting to exploit above code example
+#####################
+log_authentication_failed("guest'\nWARNING:root:User login failed for: 'administrator")
+
+
+
+# TODO: Production — keep sink-side neutralization (escape CR/LF) even with validation,
+#       prefer structured JSON logs.
+```
+
+The following output shows that a warning is logged, and the input is sanitized before logging.
+
+```bash
+WARNING:root:Rejected login attempt: invalid username="guest'\nWARNING:root:User login failed for: 'administrator"
+```
+
+## Automated Detection
+
+<table>
+  <thead>
+    <tr>
+      <th>Tool</th>
+      <th>Version</th>
+      <th>Check</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Bandit</td>
+      <td>1.7.5</td>
+      <td>Not Available</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>PyLint</td>
+      <td>2.17</td>
+      <td>Not Available</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>CodeQL</td>
+      <td>Latest</td>
+      <td><a href="https://codeql.github.com/codeql-query-help/python/py-log-injection/">py-log-injection</a></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Veracode</td>
+      <td>Latest</td>
+      <td>CWE 117</td>
+      <td><a href="https://community.veracode.com/s/article/How-to-Fix-CWE-117-Improper-Output-Neutralization-for-Logs">How to Fix CWE-117</a></td>
+    </tr>
+  </tbody>
+</table>
+
+## Related Guidelines
+
+- **CWE-117**: Improper Output Neutralization for Logs [cwe117]
+- **CWE-93**: Improper Neutralization of CRLF Sequences ('CRLF Injection') [cwe93]
+- **CWE-113**: Improper Neutralization of CRLF Sequences in HTTP Headers [cwe113]
+- **CAPEC-93**: Log Injection-Tampering-Forging [capec93]
+- **OWASP Top 10 2021**: A09 - Security Logging and Monitoring Failures [owasp_top10_2021]
+- **OWASP ASVS 4.0**: V7.1 Log Content Requirements [owasp_asvs]
+- **ISO/IEC TR 24772:2013**: Injection [RST] [iso24772]
+- **NIST SP 800-92**: Guide to Computer Security Log Management [nist80092]
+
+## Bibliography
+
+<ul>
+  <li>[cwe117] MITRE. “CWE-117: Improper Output Neutralization for Logs” [online]. Available from: <a href="https://cwe.mitre.org/data/definitions/117.html">https://cwe.mitre.org/data/definitions/117.html</a>. Accessed 23 September 2025.</li>
+  <li>[cwe93] MITRE. “CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection')” [online]. Available from: <a href="https://cwe.mitre.org/data/definitions/93.html">https://cwe.mitre.org/data/definitions/93.html</a>. Accessed 23 September 2025.</li>
+  <li>[cwe113] MITRE. “CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers” [online]. Available from: <a href="https://cwe.mitre.org/data/definitions/113.html">https://cwe.mitre.org/data/definitions/113.html</a>. Accessed 23 September 2025.</li>
+  <li>[capec93] MITRE. “CAPEC-93: Log Injection‑Tampering‑Forging” [online]. Available from: <a href="https://capec.mitre.org/data/definitions/93.html">https://capec.mitre.org/data/definitions/93.html</a>. Accessed 23 September 2025.</li>
+  <li>[nist80092] Kent, K.; Souppaya, M. “NIST Special Publication 800‑92: Guide to Computer Security Log Management” [online]. Available from: <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-92.pdf">https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-92.pdf</a>. Accessed 23 September 2025.</li>
+  <li>[owasp_asvs] OWASP. “Application Security Verification Standard 4.x” [online]. Available from: <a href="https://owasp.org/www-project-application-security-verification-standard/">https://owasp.org/www-project-application-security-verification-standard/</a>. Accessed 23 September 2025.</li>
+  <li>[owasp_top10_2021] OWASP. “OWASP Top 10 — 2021: A09 Security Logging and Monitoring Failures” [online]. Available from: <a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/</a>. Accessed 23 September 2025.</li>
+  <li>[codeql] GitHub. “Log Injection — CodeQL query help (Python)” [online]. Available from: <a href="https://codeql.github.com/codeql-query-help/python/py-log-injection/">https://codeql.github.com/codeql-query-help/python/py-log-injection/</a>. Accessed 23 September 2025.</li>
+  <li>[veracode] Veracode. “How to Fix CWE‑117 — Improper Output Neutralization for Logs” [online]. Available from: <a href="https://community.veracode.com/s/article/How-to-Fix-CWE-117-Improper-Output-Neutralization-for-Logs">https://community.veracode.com/s/article/How-to-Fix-CWE-117-Improper-Output-Neutralization-for-Logs</a>. Accessed 23 September 2025.</li>
+  <li>[iso24772] ISO/IEC. “TR 24772:2013 — Programming languages — Guidance to avoiding vulnerabilities in programming languages through language selection and use (Withdrawn)” [online]. Available from: <a href="https://www.iso.org/standard/61457.html">https://www.iso.org/standard/61457.html</a>. Accessed 23 September 2025.</li>
+</ul>

--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/compliant01.py
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/compliant01.py
@@ -1,26 +1,33 @@
 # SPDX-FileCopyrightText: OpenSSF project contributors
 # SPDX-License-Identifier: MIT
-""" Compliant Code Example """
+"""Compliant Code Example"""
+
 import logging
 import re
 
+# Allow only ASCII letters, digits, underscore, dot, and hyphen; max 64 chars
+_ALLOWED_USER = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
-def allowed_chars(user):
-    """Verify only allowed characters are used"""
-    if bool(re.compile(r"\w+").fullmatch(user)):
-        return True
-    return False
+
+def is_allowed_username(user: str) -> bool:
+    """Return True if username matches the strict allow-list."""
+    return bool(_ALLOWED_USER.fullmatch(user))
 
 
 def log_authentication_failed(user):
-    """Simplified audit logging missing RFC 5424 details"""
-    if not allowed_chars(user):
-        logging.critical("Login attempt with non-allowed characters in user name: '%s'", user)
+    """Simplified audit logging (example)"""
+    if not is_allowed_username(user):
+        # Safe summary: %r escapes CR/LF so the log remains one line
+        logging.warning("Rejected login attempt: invalid username=%r", user)
+        return
     logging.warning("User login failed for: '%s'", user)
 
 
 #####################
 # attempting to exploit above code example
 #####################
-log_authentication_failed("""foo
-WARNING:root:User login failed for: administrator""")
+log_authentication_failed("guest'\nWARNING:root:User login failed for: 'administrator")
+
+
+# TODO: Production — keep sink-side neutralization (escape CR/LF) even with validation,
+#       prefer structured JSON logs.

--- a/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/noncompliant01.py
+++ b/docs/Secure-Coding-Guide-for-Python/CWE-707/CWE-117/noncompliant01.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: OpenSSF project contributors
 # SPDX-License-Identifier: MIT
-""" Non-compliant Code Example """
+"""Non-compliant Code Example"""
+
 import logging
 
 
@@ -12,5 +13,4 @@ def log_authentication_failed(user):
 #####################
 # attempting to exploit above code example
 #####################
-log_authentication_failed("""foo
-WARNING:root:User login failed for: administrator""")
+log_authentication_failed("guest'\nWARNING:root:User login failed for: 'administrator")

--- a/docs/Secure-Coding-Guide-for-Python/readme.md
+++ b/docs/Secure-Coding-Guide-for-Python/readme.md
@@ -110,7 +110,7 @@ It is __not production code__ and requires code-style or python best practices t
 |:----------------------------------------------------------------|:----|
 |[CWE-78: Improper Neutralization of Special Elements Used in an OS Command ("OS Command Injection")](CWE-707/CWE-78/README.md)|[CVE-2024-43804](https://www.cvedetails.com/cve/CVE-2024-43804/),<br/>CVSSv3.1: __8.8__,<br/>EPSS: __00.06__ (08.11.2024)|
 |[CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')](CWE-707/CWE-89/README.md)|[CVE-2019-8600](https://www.cvedetails.com/cve/CVE-2019-8600/),<br/>CVSSv3.1: __9.8__,<br/>EPSS: __01.43__ (18.02.2024)|
-|[CWE-117: Improper Output Neutralization for Logs](CWE-707/CWE-117/.)||
+|[CWE-117: Improper Output Neutralization for Logs](CWE-707/CWE-117/README.md)||
 |[CWE-175: Improper Handling of Mixed Encoding](CWE-707/CWE-175/README.md)||
 |[CWE-180: Incorrect behavior order: Validate before Canonicalize](CWE-707/CWE-180/README.md)|[CVE-2022-26136](https://www.cvedetails.com/cve/CVE-2022-26136/),<br/>CVSSv3.1: __9.8__,<br/>EPSS: __00.18__ (24.04.2025)|
 |[CWE-838: Inappropriate Encoding for Output Context](CWE-707/CWE-838/README.md)||


### PR DESCRIPTION
Documentation and code samples for CWE-117 (Improper Output Neutralization for Logs) in the Python Secure Coding Guide.