### PR TITLE
Add CONTRIBUTING.md guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ We value all contributions, from improving documentation to participating in dis
 - All PRs are reviewed by maintainers.
 - Ensure your PR is well-documented and follows project guidelines.
 - Be open to feedback and ready to make improvements.
+- Don't hesitate to post a reminder if you didn't get any feedback after some time, e.g. two weeks.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Adds a new CONTRIBUTING.md file, based off of the file developed by the BEAR WG and also adopted by the Vulnerability Disclosures WG. This is part of our efforts to help increase community engagement and help people who are new to the community.