### PR TITLE
Adding a link to the Swedish translation of the evalution guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ This is a list of materials (documents, services, and so on) released by the
 ## Guides
 
 * [Concise Guide for Developing More Secure Software](https://best.openssf.org/Concise-Guide-for-Developing-More-Secure-Software)
-* [Concise Guide for Evaluating Open Source Software](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software)
+* [Concise Guide for Evaluating Open Source Software](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software) ([Swedish](https://best.openssf.org/sv/Concise-Guide-for-Evaluating-Open-Source-Software))
 * [npm Best Practices Guide](https://github.com/ossf/package-manager-best-practices/blob/main/published/npm.md)
 * [Source Code Management Platform Configuration Best Practices Guide](https://best.openssf.org/SCM-BestPractices/)
 * [Compiler Options Hardening Guide for C and C++](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++)


### PR DESCRIPTION
Adding the Swedish translation of the concise guide for evaluating software to the listing of guides.