### PR TITLE
pyscg-0041 - Changes to compliant01.py so that teardown runs correctly

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/01_introduction/pyscg-0041/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/01_introduction/pyscg-0041/README.md
@@ -138,7 +138,7 @@ class TestSimulateDeployingFrontEnd(unittest.TestCase):
         config["LOGGING"] = {
             "level": "DEBUG",
         }
-        self.config_file_path = Path("config.ini", exist_ok=True)
+        self.config_file_path = Path("config.ini")
         with open(self.config_file_path, "w", encoding="utf-8") as config_file:
             config.write(config_file)
         self.config_file_path.chmod(0o400)
@@ -149,6 +149,7 @@ class TestSimulateDeployingFrontEnd(unittest.TestCase):
 
     def tearDown(self):
         """Clean up after us and remove the config file"""
+        self.config_file_path.chmod(0o600)
         self.config_file_path.unlink()
 
 

--- a/docs/Secure-Coding-Guide-for-Python/01_introduction/pyscg-0041/compliant01.py
+++ b/docs/Secure-Coding-Guide-for-Python/01_introduction/pyscg-0041/compliant01.py
@@ -42,7 +42,7 @@ class TestSimulateDeployingFrontEnd(unittest.TestCase):
         config["LOGGING"] = {
             "level": "DEBUG",
         }
-        self.config_file_path = Path("config.ini", exist_ok=True)
+        self.config_file_path = Path("config.ini")
         with open(self.config_file_path, "w", encoding="utf-8") as config_file:
             config.write(config_file)
         self.config_file_path.chmod(0o400)
@@ -53,6 +53,7 @@ class TestSimulateDeployingFrontEnd(unittest.TestCase):
 
     def tearDown(self):
         """Clean up after us and remove the config file"""
+        self.config_file_path.chmod(0o600)
         self.config_file_path.unlink()
 
 


### PR DESCRIPTION
Made the changes based on the following bug:

https://github.com/ossf/wg-best-practices-os-developers/issues/1000

Changes were simply due to the teardown trying to delete a config file while in read-only mode. I now temporarily change the file to 600 permissions, and then remove it on the next line.

I also removed the "exist_ok" parameter as it's a deprecated parameter, but also wasn't being used correctly here.