### PR TITLE
pyscg, fixed quoted SOLIDUS codepoint that is u002f instead of 003f

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/02_encoding_and_strings/pyscg-0044/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/02_encoding_and_strings/pyscg-0044/README.md
@@ -40,7 +40,7 @@ Character Encoding systems such as `ASCII`, `Windows-1252`, or `UTF-8` consist o
     </tr>
     <tr>
         <td >/</td>
-        <td>\u003f</td>
+        <td>\u002f</td>
         <td>SOLIDUS</td>
         <td>／</td>
         <td>\uff0f</td>


### PR DESCRIPTION
bug, we where quoting the wrong code point.