### PR TITLE
pyscg-0037: Tweak heading test about assertions

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,6 +1,6 @@
 # pyscg-0037: Presume Assertions May Be Disabled In Production
 
-Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Only use assertions when their removal in production is acceptable. In particular, to report invalid input or incorrect function arguments, raise an appropriate exception or other such actions instead of assertions, to ensure that they will continue to occur even when assertions are removed in production.
+Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Only use assertions when their removal in production is acceptable. In particular, to report invalid input or incorrect function arguments, raise an appropriate exception or other such actions instead of assertions, to ensure that they will continue to occur even when assertions are disabled in production.
 
 Python removes assertions when a script is run with the `-O`  and `-OO` options [[Python 3.9 Documentation](https://docs.python.org/3.9/using/cmdline.html?highlight=pythonoptimize#cmdoption-o)]. The `-O` options is for optimisation. It removes asserts statements from bytecode, removes docstrings from functions/classes and sets `__debug__` to False. It is used for slightly faster execution and smaller bytecode files. `-OO` does everything that `-O`does but it additionally removes module-level docstrings and creates an even more compact bytecode.
 

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,6 +1,6 @@
 # pyscg-0037: Presume Assertions May Be Disabled In Production
 
-Assertions are a useful developer tool, but they cannot be relied upon to be applied in a production environment. 
+Assertions are a useful developer tool, but they cannot be relied upon to be applied in a production environment.
 Only use `assert` for internal invariants and debug-only checks that are *not required for correct or safe execution*.
 
 __Do not use `assert` for:__

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,6 +1,6 @@
 # pyscg-0037: Presume Assertions May Be Disabled In Production
 
-Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Only use assertions when their removal in production is acceptable. In particular, to report invalid input or incorrect function arguments, raise an appropriate exception or other such actions instead of assertions, to ensure that they will continue to occur even when assertions are disabled in production.
+Assertions are a useful developer tool, but they cannot be relied upon to be enabled in a production environment. Only use assertions when disabling them in production is acceptable. In particular, to report invalid input or incorrect function arguments, raise an appropriate exception or other such actions instead of using assertions, to ensure that they will continue to occur even when assertions are disabled in production.
 
 Python removes assertions when a script is run with the `-O`  and `-OO` options [[Python 3.9 Documentation](https://docs.python.org/3.9/using/cmdline.html?highlight=pythonoptimize#cmdoption-o)]. The `-O` options is for optimisation. It removes asserts statements from bytecode, removes docstrings from functions/classes and sets `__debug__` to False. It is used for slightly faster execution and smaller bytecode files. `-OO` does everything that `-O`does but it additionally removes module-level docstrings and creates an even more compact bytecode.
 

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,6 +1,6 @@
 # pyscg-0037: Presume Assertions May Be Disabled In Production
 
-Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Assertions can be used, but incorrect function arguments should be handled by an appropriate exception instead.
+Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Only use assertions when their removal in production is acceptable. In particular, to report invalid input or incorrect function arguments, raise an appropriate exception or other such actions instead of assertions, to ensure that they will continue to occur even when assertions are removed in production.
 
 Python removes assertions when a script is run with the `-O`  and `-OO` options [[Python 3.9 Documentation](https://docs.python.org/3.9/using/cmdline.html?highlight=pythonoptimize#cmdoption-o)]. The `-O` options is for optimisation. It removes asserts statements from bytecode, removes docstrings from functions/classes and sets `__debug__` to False. It is used for slightly faster execution and smaller bytecode files. `-OO` does everything that `-O`does but it additionally removes module-level docstrings and creates an even more compact bytecode.
 

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,4 +1,4 @@
-# pyscg-0037: Do not Depend on Assertions In Production
+# pyscg-0037: Presume Assertions May Be Disabled In Production
 
 Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Assertions can be used, but incorrect function arguments should be handled by an appropriate exception instead.
 

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -12,7 +12,7 @@ __Reason:__
 
 Python’s optimization options (`-O` and `-OO`) remove `assert` statements from the bytecode and set `__debug__` to `False`  [[Python 3.9 Documentation](https://docs.python.org/3.9/using/cmdline.html?highlight=pythonoptimize#cmdoption-o)]. This means any logic implemented using `assert` may not execute in optimized runs.
 
-As a result, using `assert` for security or correctness-critical checks can introduce vulnerabilities or undefined behavior regardless if optimization is enabled. Its neither recommended to depend on `-O` or `-OO` as a "switch" to make assertions unreachable. 
+As a result, using `assert` incorrectly (that is, for security or correctness-critical checks) can introduce vulnerabilities or other undesired behavior when optimization is enabled.
 
 Instead, raise appropriate exceptions to ensure the checks are always enforced regardless of interpreter settings.
 

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,6 +1,6 @@
-# pyscg-0037: Avoid Assertions In Production
+# pyscg-0037: Do not Depend on Assertions In Production
 
-Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Incorrect function arguments should be handled by an appropriate exception.
+Assertions are a useful developer tool, but they cannot be relied upon to be present in a production environment. Assertions can be used, but incorrect function arguments should be handled by an appropriate exception instead.
 
 Python removes assertions when a script is run with the `-O`  and `-OO` options [[Python 3.9 Documentation](https://docs.python.org/3.9/using/cmdline.html?highlight=pythonoptimize#cmdoption-o)]. The `-O` options is for optimisation. It removes asserts statements from bytecode, removes docstrings from functions/classes and sets `__debug__` to False. It is used for slightly faster execution and smaller bytecode files. `-OO` does everything that `-O`does but it additionally removes module-level docstrings and creates an even more compact bytecode.
 

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,6 +1,6 @@
 # pyscg-0037: Presume Assertions May Be Disabled In Production
 
-suggestion
+Assertions are a useful developer tool, but they cannot be relied upon to be applied in a production environment. 
 Only use `assert` for internal invariants and debug-only checks that are *not required for correct or safe execution*.
 
 __Do not use `assert` for:__

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -1,8 +1,20 @@
 # pyscg-0037: Presume Assertions May Be Disabled In Production
 
-Assertions are a useful developer tool, but they cannot be relied upon to be enabled in a production environment. Only use assertions when disabling them in production is acceptable. In particular, to report invalid input or incorrect function arguments, raise an appropriate exception or other such actions instead of using assertions, to ensure that they will continue to occur even when assertions are disabled in production.
+suggestion
+Only use `assert` for internal invariants and debug-only checks that are *not required for correct or safe execution*.
 
-Python removes assertions when a script is run with the `-O`  and `-OO` options [[Python 3.9 Documentation](https://docs.python.org/3.9/using/cmdline.html?highlight=pythonoptimize#cmdoption-o)]. The `-O` options is for optimisation. It removes asserts statements from bytecode, removes docstrings from functions/classes and sets `__debug__` to False. It is used for slightly faster execution and smaller bytecode files. `-OO` does everything that `-O`does but it additionally removes module-level docstrings and creates an even more compact bytecode.
+__Do not use `assert` for:__
+* Security checks (including input validation)
+* Enforcing runtime conditions whose removal would affect correctness or security
+* Error handling
+
+__Reason:__
+
+Python’s optimization options (`-O` and `-OO`) remove `assert` statements from the bytecode and set `__debug__` to `False`  [[Python 3.9 Documentation](https://docs.python.org/3.9/using/cmdline.html?highlight=pythonoptimize#cmdoption-o)]. This means any logic implemented using `assert` may not execute in optimized runs.
+
+As a result, using `assert` for security or correctness-critical checks can introduce vulnerabilities or undefined behavior regardless if optimization is enabled. Its neither recommended to depend on `-O` or `-OO` as a "switch" to make assertions unreachable. 
+
+Instead, raise appropriate exceptions to ensure the checks are always enforced regardless of interpreter settings.
 
 ## Non-Compliant Code Example
 

--- a/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/08_coding_standards/pyscg-0037/README.md
@@ -4,6 +4,7 @@ Assertions are a useful developer tool, but they cannot be relied upon to be app
 Only use `assert` for internal invariants and debug-only checks that are *not required for correct or safe execution*.
 
 __Do not use `assert` for:__
+
 * Security checks (including input validation)
 * Enforcing runtime conditions whose removal would affect correctness or security
 * Error handling


### PR DESCRIPTION
It's not that you *can't* use assertions, it's that you need to not depend on their utility in production. Leaving them in is fine, as long as you don't depend on them firing during production.