### PR TITLE
PSCG: fixing links in html tables

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0012/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0012/README.md
@@ -321,11 +321,11 @@ The `compliant01.py` code will extract everything below the provided `base_path`
     </tr>
     <tr>
         <td>Secure Coding in Python</td>
-        <td>Base: <a href="../../02_encoding_and_strings/pyscg-0044/README.md">pyscg-0044: Canonicalize Input Before Validating</a></td>
+        <td>Base: <a href="../../02_encoding_and_strings/pyscg-0044/">pyscg-0044: Canonicalize Input Before Validating</a></td>
     </tr>
     <tr>
         <td>Secure Coding in Python</td>
-        <td>Base: <a href="../../06_logging/pyscg-0050/README.md">pyscg-0050: Sanitize Error Output to Prevent Information Disclosure</a></td>
+        <td>Base: <a href="../../06_logging/pyscg-0050/">pyscg-0050: Sanitize Error Output to Prevent Information Disclosure</a></td>
     </tr>
     <tr>
         <td><a href="https://wiki.sei.cmu.edu/confluence/display/java/SEI+CERT+Oracle+Coding+Standard+for+Java">[SEI CERT Oracle Coding Standard for Java]</a></td>

--- a/docs/Secure-Coding-Guide-for-Python/readme.md
+++ b/docs/Secure-Coding-Guide-for-Python/readme.md
@@ -53,25 +53,25 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="01_introduction/pyscg-0040/README.md">pyscg-0040: Use Process Isolation for Trust Zones</a></td>
+<td><a href="01_introduction/pyscg-0040/">pyscg-0040: Use Process Isolation for Trust Zones</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2023-28597">CVE-2023-28597</a>,<br>CVSSv3.0: <strong style='color:orange'>7.5</strong>,<br>EPSS: <strong>00.11</strong> (05.11.2024)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/501.html">CWE-501</a></td>
 </tr>
 
 <tr>
-<td><a href="01_introduction/pyscg-0041/README.md">pyscg-0041: Externalize Configuration and Secrets</a></td>
+<td><a href="01_introduction/pyscg-0041/">pyscg-0041: Externalize Configuration and Secrets</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/798.html">CWE-798</a></td>
 </tr>
 
 <tr>
-<td><a href="01_introduction/pyscg-0042/README.md">pyscg-0042: Ensure Correct Operator Precedence</a></td>
+<td><a href="01_introduction/pyscg-0042/">pyscg-0042: Ensure Correct Operator Precedence</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/783.html">CWE-783</a></td>
 </tr>
 
 <tr>
-<td><a href="01_introduction/pyscg-0055/README.md">pyscg-0055: Determine Access on Server Side</a></td>
+<td><a href="01_introduction/pyscg-0055/">pyscg-0055: Determine Access on Server Side</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/472.html">CWE-472</a></td>
 </tr>
@@ -83,19 +83,19 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="02_encoding_and_strings/pyscg-0043/README.md">pyscg-0043: Specify Locale Explicitly</a></td>
+<td><a href="02_encoding_and_strings/pyscg-0043/">pyscg-0043: Specify Locale Explicitly</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/175.html">CWE-175</a></td>
 </tr>
 
 <tr>
-<td><a href="02_encoding_and_strings/pyscg-0044/README.md">pyscg-0044: Canonicalize Input Before Validating</a></td>
+<td><a href="02_encoding_and_strings/pyscg-0044/">pyscg-0044: Canonicalize Input Before Validating</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2022-26136/">CVE-2022-26136</a>,<br>CVSSv3.1: <strong style='color:red'>9.8</strong>,<br>EPSS: <strong>00.28</strong> (31.12.2025)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/180.html">CWE-180</a></td>
 </tr>
 
 <tr>
-<td><a href="02_encoding_and_strings/pyscg-0045/README.md">pyscg-0045: Enforce Consistent Encoding</a></td>
+<td><a href="02_encoding_and_strings/pyscg-0045/">pyscg-0045: Enforce Consistent Encoding</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/176.html">CWE-176</a></td>
 </tr>
@@ -107,43 +107,43 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="03_numbers/pyscg-0001/README.md">pyscg-0001: Control Numeric Precision</a></td>
+<td><a href="03_numbers/pyscg-0001/">pyscg-0001: Control Numeric Precision</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/1339.html">CWE-1339</a></td>
 </tr>
 
 <tr>
-<td><a href="03_numbers/pyscg-0002/README.md">pyscg-0002: Guard Fixed-Width Numbers Against Overflow</a></td>
+<td><a href="03_numbers/pyscg-0002/">pyscg-0002: Guard Fixed-Width Numbers Against Overflow</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/191.html">CWE-191</a>, <a href="https://cwe.mitre.org/data/definitions/190.html">CWE-190</a></td>
 </tr>
 
 <tr>
-<td><a href="03_numbers/pyscg-0003/README.md">pyscg-0003: Use Arithmetic Over Bitwise Operations</a></td>
+<td><a href="03_numbers/pyscg-0003/">pyscg-0003: Use Arithmetic Over Bitwise Operations</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/1335.html">CWE-1335</a></td>
 </tr>
 
 <tr>
-<td><a href="03_numbers/pyscg-0004/README.md">pyscg-0004: Use Integer Loop Counters</a></td>
+<td><a href="03_numbers/pyscg-0004/">pyscg-0004: Use Integer Loop Counters</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/197.html">CWE-197</a></td>
 </tr>
 
 <tr>
-<td><a href="03_numbers/pyscg-0005/README.md">pyscg-0005: Specify Rounding for Numeric Conversions</a></td>
+<td><a href="03_numbers/pyscg-0005/">pyscg-0005: Specify Rounding for Numeric Conversions</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/197.html">CWE-197</a></td>
 </tr>
 
 <tr>
-<td><a href="03_numbers/pyscg-0006/README.md">pyscg-0006: Use an Appropriate Comparator for Numbers</a></td>
+<td><a href="03_numbers/pyscg-0006/">pyscg-0006: Use an Appropriate Comparator for Numbers</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/681.html">CWE-681</a></td>
 </tr>
 
 <tr>
-<td><a href="03_numbers/pyscg-0007/README.md">pyscg-0007: Use String Literals for Decimal Construction</a></td>
+<td><a href="03_numbers/pyscg-0007/">pyscg-0007: Use String Literals for Decimal Construction</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/681.html">CWE-681</a></td>
 </tr>
@@ -155,49 +155,49 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0047/README.md">pyscg-0047: Use Allow Lists Over Deny Lists</a></td>
+<td><a href="04_neutralization/pyscg-0047/">pyscg-0047: Use Allow Lists Over Deny Lists</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/184.html">CWE-184</a></td>
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0008/README.md">pyscg-0008: Prevent Format String Injection</a></td>
+<td><a href="04_neutralization/pyscg-0008/">pyscg-0008: Prevent Format String Injection</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2022-27177/">CVE-2022-27177</a>,<br>CVSSv3.1: <strong style='color:darkred'>9.8</strong>,<br>EPSS: <strong>00.37</strong> (01.12.2023)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/134.html">CWE-134</a></td>
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0009/README.md">pyscg-0009: Prevent OS Command Injection</a></td>
+<td><a href="04_neutralization/pyscg-0009/">pyscg-0009: Prevent OS Command Injection</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2024-43804/">CVE-2024-43804</a>,<br>CVSSv3.1: <strong>8.8</strong>,<br>EPSS: <strong>00.06</strong> (08.11.2024)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/78.html">CWE-78</a></td>
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0010/README.md">pyscg-0010: Prevent SQL Injection</a></td>
+<td><a href="04_neutralization/pyscg-0010/">pyscg-0010: Prevent SQL Injection</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2019-8600">CVE-2019-8600</a>,<br>CVSSv3.1: <strong style='color:red'>9.8</strong>,<br>EPSS: <strong>01.43</strong> (18.02.2024)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/89.html">CWE-89</a></td>
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0011/README.md">pyscg-0011: Prevent Type Confusion</a></td>
+<td><a href="04_neutralization/pyscg-0011/">pyscg-0011: Prevent Type Confusion</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2021-29513">CVE-2021-29513</a>,<br>CVSSv3.1: <strong style='color:orange'>7.8</strong>,<br>EPSS: <strong>00.02</strong> (13.05.2025)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/843.html">CWE-843</a></td>
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0012/README.md">pyscg-0012: Extract Archives Safely</a></td>
+<td><a href="04_neutralization/pyscg-0012/">pyscg-0012: Extract Archives Safely</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2019-9674/">CVE-2019-9674</a>,<br>CVSSv3.1: <strong style='color:orange'>7.5</strong>,<br>EPSS: <strong>1.2%</strong> (10.09.2025)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/409.html">CWE-409</a></td>
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0013/README.md">pyscg-0013: Secure Search Paths</a></td>
+<td><a href="04_neutralization/pyscg-0013/">pyscg-0013: Secure Search Paths</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2015-1326">CVE-2015-1326</a>,<br>CVSSv3.0: <strong style='color:red'>8.8</strong>,<br>EPSS: <strong>00.20</strong> (23.11.2023)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/426.html">CWE-426</a></td>
 </tr>
 
 <tr>
-<td><a href="04_neutralization/pyscg-0023/README.md">pyscg-0023: Secure Deserialization</a></td>
+<td><a href="04_neutralization/pyscg-0023/">pyscg-0023: Secure Deserialization</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2018-8021">CVE-2018-8021</a>,<br>CVSSv3.0: <strong style='color:red'>9.8</strong>,<br>EPSS: <strong>93.54</strong> (05.11.2024)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/502.html">CWE-502</a></td>
 </tr>
@@ -209,37 +209,37 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="05_exception_handling/pyscg-0014/README.md">pyscg-0014: Use Specific Exception Types</a></td>
+<td><a href="05_exception_handling/pyscg-0014/">pyscg-0014: Use Specific Exception Types</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/397.html">CWE-397</a></td>
 </tr>
 
 <tr>
-<td><a href="05_exception_handling/pyscg-0015/README.md">pyscg-0015: Handle Error Conditions</a></td>
+<td><a href="05_exception_handling/pyscg-0015/">pyscg-0015: Handle Error Conditions</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2024-39560">CVE-2024-39560</a>,<br>CVSSv3.1: <strong style='color:yellow'>6.5</strong>,<br>EPSS: <strong>0.04</strong> (01.11.2024)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/755.html">CWE-755</a></td>
 </tr>
 
 <tr>
-<td><a href="05_exception_handling/pyscg-0016/README.md">pyscg-0016: Propagate Exceptions and Preserve Context</a></td>
+<td><a href="05_exception_handling/pyscg-0016/">pyscg-0016: Propagate Exceptions and Preserve Context</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/396.html">CWE-396</a></td>
 </tr>
 
 <tr>
-<td><a href="05_exception_handling/pyscg-0018/README.md">pyscg-0018: Validate Numeric Data Beyond Type Checking</a></td>
+<td><a href="05_exception_handling/pyscg-0018/">pyscg-0018: Validate Numeric Data Beyond Type Checking</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/754.html">CWE-754</a></td>
 </tr>
 
 <tr>
-<td><a href="05_exception_handling/pyscg-0028/README.md">pyscg-0028: Preserve Exceptions in Finally Blocks</a></td>
+<td><a href="05_exception_handling/pyscg-0028/">pyscg-0028: Preserve Exceptions in Finally Blocks</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/584.html">CWE-584</a></td>
 </tr>
 
 <tr>
-<td><a href="05_exception_handling/pyscg-0052/README.md">pyscg-0052: Ensure Cleanup on Exceptions</a></td>
+<td><a href="05_exception_handling/pyscg-0052/">pyscg-0052: Ensure Cleanup on Exceptions</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/460.html">CWE-460</a></td>
 </tr>
@@ -251,73 +251,73 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="06_logging/pyscg-0019/README.md">pyscg-0019: Exclude Sensitive Data From Logs</a></td>
+<td><a href="06_logging/pyscg-0019/">pyscg-0019: Exclude Sensitive Data From Logs</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2023-45585">CVE-2023-45585</a>,<br>CVSSv3.1: <strong>9.8</strong>,<br>EPSS: <strong>0.04</strong> (01.11.2024)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/532.html">CWE-532</a></td>
 </tr>
 
 <tr>
-<td><a href="06_logging/pyscg-0020/README.md">pyscg-0020: Implement Informative Event Logging</a></td>
+<td><a href="06_logging/pyscg-0020/">pyscg-0020: Implement Informative Event Logging</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/778.html">CWE-778</a></td>
 </tr>
 
 <tr>
-<td><a href="06_logging/pyscg-0021/README.md">pyscg-0021: Exclude Developer Tools From the Final Product</a></td>
+<td><a href="06_logging/pyscg-0021/">pyscg-0021: Exclude Developer Tools From the Final Product</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2018-14649">CVE-2018-14649</a>,<br>CVSSv3.1: <strong style='color:red'>9.8</strong>,<br>EPSS: <strong>69.64</strong> (12.12.2023)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/489.html">CWE-489</a></td>
 </tr>
 
 <tr>
-<td><a href="06_logging/pyscg-0022/README.md">pyscg-0022: Neutralize Untrusted Data in Logs</a></td>
+<td><a href="06_logging/pyscg-0022/">pyscg-0022: Neutralize Untrusted Data in Logs</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/117.html">CWE-117</a></td>
 </tr>
 
 <tr>
-<td><a href="06_logging/pyscg-0050/README.md">pyscg-0050: Sanitize Error Output to Prevent Information Disclosure</a></td>
+<td><a href="06_logging/pyscg-0050/">pyscg-0050: Sanitize Error Output to Prevent Information Disclosure</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/209.html">CWE-209</a></td>
 </tr>
 
 <tr>
-<th><a href="07_concurrency/readme.md">07 Concurrency</a></th>
+<th><a href="07_concurrency/">07 Concurrency</a></th>
 <th>Prominent CVE</th>
 <th>MITRE</th>
 </tr>
 
 <tr>
-<td><a href="07_concurrency/pyscg-0024/README.md">pyscg-0024: Ensure Thread Pool Tasks Can Be Interrupted</a></td>
+<td><a href="07_concurrency/pyscg-0024/">pyscg-0024: Ensure Thread Pool Tasks Can Be Interrupted</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/400.html">CWE-400</a></td>
 </tr>
 
 <tr>
-<td><a href="07_concurrency/pyscg-0025/README.md">pyscg-0025: Configure Adequate Resource Pools</a></td>
+<td><a href="07_concurrency/pyscg-0025/">pyscg-0025: Configure Adequate Resource Pools</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/410.html">CWE-410</a></td>
 </tr>
 
 <tr>
-<td><a href="07_concurrency/pyscg-0026/README.md">pyscg-0026: Prevent Deadlocks</a></td>
+<td><a href="07_concurrency/pyscg-0026/">pyscg-0026: Prevent Deadlocks</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/833.html">CWE-833</a></td>
 </tr>
 
 <tr>
-<td><a href="07_concurrency/pyscg-0027/README.md">pyscg-0027: Prevent Race Conditions</a></td>
+<td><a href="07_concurrency/pyscg-0027/">pyscg-0027: Prevent Race Conditions</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/362.html">CWE-362</a></td>
 </tr>
 
 <tr>
-<td><a href="07_concurrency/pyscg-0029/README.md">pyscg-0029: Reinitialize Reused Thread Objects</a></td>
+<td><a href="07_concurrency/pyscg-0029/">pyscg-0029: Reinitialize Reused Thread Objects</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/665.html">CWE-665</a></td>
 </tr>
 
 <tr>
-<td><a href="07_concurrency/pyscg-0030/README.md">pyscg-0030: Ensure Thread Pool Tasks Do Not Fail Silently</a></td>
+<td><a href="07_concurrency/pyscg-0030/">pyscg-0030: Ensure Thread Pool Tasks Do Not Fail Silently</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/392.html">CWE-392</a></td>
 </tr>
@@ -329,49 +329,49 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0031/README.md">pyscg-0031: Use Copies When Modifying Iterables</a></td>
+<td><a href="08_coding_standards/pyscg-0031/">pyscg-0031: Use Copies When Modifying Iterables</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/1095.html">CWE-1095</a></td>
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0032/README.md">pyscg-0032: Avoid Redefining Built-in Functions or Standard Library Identifiers</a></td>
+<td><a href="08_coding_standards/pyscg-0032/">pyscg-0032: Avoid Redefining Built-in Functions or Standard Library Identifiers</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/1109.html">CWE-1109</a></td>
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0033/README.md">pyscg-0033: Implement Comparisons by Value Rather Than Reference</a></td>
+<td><a href="08_coding_standards/pyscg-0033/">pyscg-0033: Implement Comparisons by Value Rather Than Reference</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/595.html">CWE-595</a></td>
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0034/README.md">pyscg-0034: Check for None Values</a></td>
+<td><a href="08_coding_standards/pyscg-0034/">pyscg-0034: Check for None Values</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/476.html">CWE-476</a></td>
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0035/README.md">pyscg-0035: Complete Resource Cleanup</a></td>
+<td><a href="08_coding_standards/pyscg-0035/">pyscg-0035: Complete Resource Cleanup</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/459.html">CWE-459</a></td>
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0036/README.md">pyscg-0036: Check Return Values</a></td>
+<td><a href="08_coding_standards/pyscg-0036/">pyscg-0036: Check Return Values</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/252.html">CWE-252</a></td>
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0037/README.md">pyscg-0037: Avoid Assertions In Production</a></td>
+<td><a href="08_coding_standards/pyscg-0037/">pyscg-0037: Avoid Assertions In Production</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/617.html">CWE-617</a></td>
 </tr>
 
 <tr>
-<td><a href="08_coding_standards/pyscg-0051/README.md">pyscg-0051: Release Unused Resources</a></td>
+<td><a href="08_coding_standards/pyscg-0051/">pyscg-0051: Release Unused Resources</a></td>
 <td></td>
 <td><a href="https://cwe.mitre.org/data/definitions/404.html">CWE-404</a></td>
 </tr>
@@ -383,7 +383,7 @@ It is __not production code__ and requires code-style or python best practices t
 </tr>
 
 <tr>
-<td><a href="09_cryptography/pyscg-0038/README.md">pyscg-0038: Use Sufficiently Random Values</a></td>
+<td><a href="09_cryptography/pyscg-0038/">pyscg-0038: Use Sufficiently Random Values</a></td>
 <td><a href="https://www.cvedetails.com/cve/CVE-2020-7548">CVE-2020-7548</a>,<br>CVSSv3.1: <strong style='color:red'>9.8</strong>,<br>EPSS: <strong>0.22</strong> (12.12.2024)</td>
 <td><a href="https://cwe.mitre.org/data/definitions/330.html">CWE-330</a></td>
 </tr>


### PR DESCRIPTION
This removes the target markdown file from <a> links used in html tables as these do not get rendered correctly on GitHub pages and thus point to the plain text markdown files on best.openssf.org

Fixes #1089 