### PR TITLE
PSCG: Adding the Python Secure Coding Guide to released artifacts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ This is a list of materials (documents, services, and so on) released by the
 * [The Memory Safety Continuum](https://memorysafety.openssf.org/memory-safety-continuum)
 * [Cyber Resilience Act (CRA) Brief Guide for Open Source Software (OSS) Developers](https://best.openssf.org/CRA-Brief-Guide-for-OSS-Developers)
 * [Security Focused Guide for AI Code Assistant Instructions](https://best.openssf.org/Security-Focused-Guide-for-AI-Code-Assistant-Instructions)
+* [Secure Coding One Stop Shop for Python](https://best.openssf.org/Secure-Coding-Guide-for-Python/)
 
 Note: You can also see the larger list of
 [Guides released by the OpenSSF](https://openssf.org/resources/guides/).
@@ -47,10 +48,6 @@ The OpenSSF Best Practices WG is working on many more materials, such as
 more educational materials through our education special interest group (SIG),
 compiler hardening guides,
 guidance about memory safety through our memory safety SIG, and so on.
-
-Examples of ongoing work include:
-
-* [Secure Coding One Stop Shop for Python](Secure-Coding-Guide-for-Python/readme.md)
 
 ## Collaborations
 


### PR DESCRIPTION
This moves the link to the Python Secure Coding Guide from the "work in progress" section to the "released guides" section.

It also fixes the link.