### PR TITLE
Update the deserialization section

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0023/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0023/README.md
@@ -1,20 +1,31 @@
-# pyscg-0023: Secure Deserialization
+# pyscg-0023: Secure Deserialization (including pickle)
 
-Even if data has been created from a trusted source, we need to verify that it has not been tampered with during transport.
+When loading data into your program ("deserializing"), do not permit an attack. Only load data (1) from a trusted source *or* (2) by using a secure loading process. Where practical, do both.
 
-The `pickle` module is known to be vulnerable [[docs.python.org 2023]](https://docs.python.org/3.9/library/pickle.html) against unwanted code execution during deserialization and should only be used if there is no architectural text-based alternative.
+You may consider data to be trusted once you verify that it's digitally signed by a trusted source. If you take this approach, you must ensure an attacker cannot gain access to the signing keys, that attackers can't cause the system to accept attacker's signatures, and that the signing algorithm is cryptographically secure. If this will be deployed in 2029 or later, it should use a quantum-resistant algorithm (e.g., HMAC with 256 bit or longer keys).
+
+Prefer storing and loading data only in formats like JSON that are safe to load by default. That's the simplest approach. Most of the text in this section exists to help developers who aren't taking the simplest approach.
+
+If used correctly, `XML` [[xml]](https://docs.python.org/3/library/xml.html#xml-security) and `YAML` [[fkkarakurt]](https://dev.to/fkkarakurt/be-careful-when-using-yaml-in-python-there-may-be-security-vulnerabilities-3cdb) are *often* safe in Python if used correctly, but see the notes below. You might choose to avoid them because they are often *not* safe by default in other ecosystems.
+
+Where practical, do *not* load `pickle` files from untrusted sources, and don't send `pickle` files either. That's because loading a pickle runs arbitrary programs by default. You are supposed to only unpickle data that you completely trust [[docs.python.org 2023]](https://docs.python.org/3.9/library/pickle.html). Using pickle is one of the most common security vulnerabilities in Python; [Paws in the Pickle Jar: Risk & Vulnerability in the Model-sharing Ecosystem](https://www.splunk.com/en_us/blog/security/paws-in-the-pickle-jar-risk-vulnerability-in-the-model-sharing-ecosystem.html) reports that, "more than 80% of the evaluated machine learning models in the ecosystem consist of pickle-serialized code, which is vulnerable to code injection / arbitrary code execution risks". If you *must* use pickle, use special precautions. The `shelve` module is backed by pickle and carries the same risks.
+
+Do not use `marshal` for storing and retrieving untrusted data; that is not its purpose. Its format is intentionally undocumented and changeable.
 
 Security-related concerns during object serialization and deserialization include:
 
-* Prefer text-based formats such as `JSON` or `YAML` if possible.
-* Consider using `Base64` encoding for binary data
-* Only unpickle data you trust \[docs.python.org 2023\].
-* Restricting Globals during deserialization.
-* Prefer `xmlrpc.client` for network operations that are already `XML` based.
-* Sign data that is crossing trust boundaries with `hmac`.
-* Use Input validation.
+* Consider signing data that is crossing trust boundaries and verify the data signature before loading. One approach is using `hmac`, which uses shared keys. If you do, use `hmac.compare_digest()` for the signature verification to resist timing attacks. However, signatures only work if an attacker cannot gain access to the signing keys and cannot cause their own signatures to be used. Asymmetric signing with X.509 certificates (e.g., with `cryptography.x509`) avoids the need to share a secret key between signer and verifier, though the signer's private key must still be protected.
+* Prefer formats like `JSON` that *never* permit running arbitrary code or unrestricted expansion when deserializing.
+* Consider using `Base64` encoding if you must encode binary data in a text format (like JSON).
+* Consider using safe formats instead of insecure formats, such as [safetensors](https://github.com/safetensors/safetensors) and BSON. Note that this will often require using external packages.
+* Loading `XML` data with the Python built-in `xml` libraries is safe today if it's a reasonably recent version of Python and `import pyexpat; pyexpat.version_info >= (2, 7, 2)`. That's because this combination does not have the XML External Entity (XXE) vulnerability that affects some other ecosystems and is no longer vulnerable to "decompression bomb" attacks. Historically `defusedxml` was recommended instead but this is no longer necessary [[xml]](https://docs.python.org/3/library/xml.html#xml-security)] [[status-defusedxml](https://discuss.python.org/t/status-of-defusedxml-and-recommendation-in-docs/34762/21)]. Consider avoiding sending XML, , since in other ecosystems it's not safe to load by default.
+* Use `xmlrpc` with care. `xmlrpc.server` exposes registered Python functions to any reachable caller with no built-in authentication or authorization. Registering an object instance exposes all its public methods, including inherited ones, which is often more than intended. Enabling `allow_dotted_names=True` is particularly severe: it lets callers walk Python attribute chains to reach `os`, `sys`, or other interfaces and achieve Remote Code Execution (RCE). Neither the server nor the client provides TLS by default; add it explicitly (e.g., via an HTTPS reverse proxy or `ssl.SSLContext`) — do not assume the network is safe. On the client side, `xmlrpc.client` parses XML responses from the server it connects to; if that server is compromised, the client processes attacker-controlled XML regardless of transport security.
+* If you load untrusted `YAML` data, use `safe_load` not `load`. It is *not* safe to use `load` in typical implementations, as this can run arbitrary programs via YAML tags [[fkkarakurt]](https://dev.to/fkkarakurt/be-careful-when-using-yaml-in-python-there-may-be-security-vulnerabilities-3cdb). Cosider avoid sending YAML, since in other ecosystems it's not safe to load by default.
+* Only unpickle data you completely trust \[docs.python.org 2023\] unless you take special precautions.
+* If you *must* load untrusted `pickle` data, use `pickle.Unpickler` and `find_class` with an allowlist of permitted classes, and ensure no attacks can occur via those allowed classes [[docs.python.org 2023]](https://docs.python.org/3.9/library/pickle.html). An example is below. This process is complicated because `pickle` is not intended for safe use on untrusted data.
+* Perform input validation. Ensure all loaded data values are strictly validated. Ideally you'd do this before or during loading, but few libraries support this. At least do this immediately after loading the data before you use it.
 
-## Noncompliant Code Example
+## Noncompliant Code Example 1
 
 The `noncompliant01.py`  code demonstrates arbitrary code execution using `os.system` to launch a program during unpickling when `pickle.loads()` [[Checkoway Oct 2013](https://checkoway.net/musings/pickle/)]
 
@@ -95,17 +106,21 @@ message = None
 message = p3.uncan(PAYLOAD)
 ```
 
-The deserializating `Preserver.uncan()` method has no solution to verify the content prior to unpickling it and runs the PAYLOAD even before turning it into an object. On Windows you have `calc.exe`  and on Unix a bunch of commands such as `uname -a and ls -la /etc/shadow`.
+The deserializing `Preserver.uncan()` method has no solution to verify the content prior to unpickling it and runs the PAYLOAD even before turning it into an object. On Windows you have `calc.exe`  and on Unix a bunch of commands such as `uname -a and ls -la /etc/shadow`.
+
+## Example 1: HMAC Integrity Protection
+
+The `example01.py` code shows how HMAC signing can detect tampering with a pickle stream before it is unpickled. It is provided to illustrate this specific technique, not as a complete or production-ready solution.
 
 > [!CAUTION]
 > The `example01.py` code only demonstrates integrity protection with hmac.
 > The pickled object is not encrypted and key-handling is inappropriate!
-> Consider using proper key management with `x509` and encryption [[pyca/cryptography 2023]](https://cryptography.io/en/latest/).
+> Consider using proper key management and encryption [[pyca/cryptography 2023]](https://cryptography.io/en/latest/).
 
 *[example01.py](example01.py):*
 
 ```py
-""" Compliant Code Example """
+""" Example Code: HMAC integrity protection with pickle """
 import hashlib
 import hmac
 import platform
@@ -137,7 +152,7 @@ class Preserver(object):
                 _jar (bytes): pickled jar as string
         """
         _jar = pickle.dumps(_message)
-        _digest = hmac.new(self._key, _jar, hashlib.sha256).hexdigest()
+        _digest = hmac.HMAC(self._key, _jar, hashlib.sha256).hexdigest()
         return _digest, _jar
 
     def uncan(self, _expected_digest, _jar) -> Message:
@@ -148,8 +163,8 @@ class Preserver(object):
             Returns:
                 (Message): Message object
         """
-        _digest = hmac.new(self._key, _jar, hashlib.sha256).hexdigest()
-        if _expected_digest != _digest:
+        _digest = hmac.HMAC(self._key, _jar, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(_expected_digest, _digest):
             raise ValueError("Integrity of jar compromised")
         return pickle.loads(_jar)
 
@@ -193,11 +208,224 @@ message = None
 message = p3.uncan(digest, PAYLOAD)
 ```
 
-The integrity verification in `compliant01.py` throws an exception `ValueError: Integrity of jar compromised prior to deserializationunpickling to prevent the PAYLOAD executed.`
+The integrity verification in `example01.py` throws a `ValueError: Integrity of jar compromised` exception, preventing the payload from being unpickled.
 
-## Compliant Solution JSON without pickle
+## Example 2: Allowlist-based Secure Pickle Loading
 
-Text-based formats, such as `JSON` and `YAML`, should always be preferred. They have a lower set of capabilities and reduce the attack surface \[python.org comparison-with-json 2023\] when compared to `pickle`.
+The `example02.py` code shows how to load pickle data securely by restricting which classes and callables pickle is permitted to resolve. Pickle executes code by looking up `(module, name)` pairs and invoking the resulting objects; `__reduce__` is the most common path (a class returns a `(callable, args)` pair that pickle invokes on load), but `__new__`, `__setstate__`, and raw GLOBAL opcodes follow the same resolution path. Overriding `find_class()` to raise `UnpicklingError` for anything outside an explicit allowlist blocks all of them.
+
+> [!CAUTION]
+> `SafeUnpickler` prevents code execution during loading but does **not** automatically validate field values. An attacker who controls the pickle stream may still inject malicious strings, SQL fragments, or out-of-range numbers into a loaded object's attributes. The `validate_orders` function below demonstrates the required second step: always validate both structure and domain constraints on every loaded object before use.
+
+*[example02.py](example02.py):*
+
+```py
+# SPDX-FileCopyrightText: OpenSSF project contributors
+# SPDX-License-Identifier: MIT
+""" Example Code: secure loading of pickle data """
+
+# pickle is widely used but unsafe by default: loading a pickle stream can
+# execute arbitrary code. This module provides an allowlist-based defence:
+#
+#   Only classes explicitly approved by the caller are permitted.
+#   This blocks code execution during loading (__reduce__ exploits).
+#
+# This module controls *what kinds of objects* are allowed to load, mirroring
+# how json.loads controls what kinds of values JSON can represent. It does NOT
+# validate data values; ensuring that loaded values are safe and correct
+# remains the caller's responsibility, just as it is with json.loads.
+#
+# Quick start:
+#
+#   from example02 import SafeUnpickler
+#
+#   loader = SafeUnpickler(allowed_classes=[MyRecord])
+#   record = loader.safe_loads(raw_bytes)
+#   # validate record's field values here before use
+#
+# Run doctests:
+#
+#   python3 -m doctest example02.py
+
+import builtins
+import datetime
+import decimal
+import io
+import pickle
+import types
+import uuid
+from collections.abc import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Default allowlist
+# ---------------------------------------------------------------------------
+
+# Build the default set from concrete class objects so that module renames or
+# reimports cannot silently widen the allowlist.
+_PICKLE_SAFE_CLASSES = (
+    # Built-in primitives and containers.
+    # These cannot execute code on load, though they can carry attacker-
+    # controlled string data; always validate values after loading.
+    builtins.str, builtins.int, builtins.float, builtins.bool,
+    builtins.bytes, builtins.bytearray, type(None),
+    builtins.list, builtins.tuple, builtins.dict,
+    builtins.set, builtins.frozenset, builtins.complex,
+    builtins.range, builtins.slice,
+
+    # Immutable stdlib value types with well-defined structure.
+    datetime.date, datetime.time, datetime.datetime,
+    datetime.timedelta, datetime.timezone,
+    decimal.Decimal,
+    uuid.UUID,
+
+    # Unvalidated carriers: safe to unpickle but may hold arbitrary string
+    # data. Several exceptions included because pickle is widely used for
+    # inter-process communication (IPC) where exceptions are routinely
+    # serialized. SimpleNamespace is a common lightweight container.
+    builtins.Exception, builtins.ValueError, builtins.TypeError,
+    builtins.KeyError, builtins.IndexError, builtins.AttributeError,
+    builtins.RuntimeError,
+    types.SimpleNamespace,
+)
+
+PICKLE_SAFE_TYPES: frozenset = frozenset(
+    (cls.__module__, cls.__name__) for cls in _PICKLE_SAFE_CLASSES
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal restricted unpickler
+# ---------------------------------------------------------------------------
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that blocks every class not in allowed_globals.
+
+    Not part of the public API; use SafeUnpickler instead.
+    pickle.Unpickler is bound to one file at construction and is
+    single-use; SafeUnpickler holds the allowlist configuration and
+    creates a fresh instance of this class for each load.
+    """
+
+    def __init__(self, file, allowed_globals: frozenset):
+        super().__init__(file)
+        self._allowed_globals = allowed_globals
+
+    def find_class(self, module: str, name: str):
+        if (module, name) in self._allowed_globals:
+            mod = __import__(module, fromlist=[name])
+            return getattr(mod, name)
+        raise pickle.UnpicklingError(
+            f"Security block: '{module}.{name}' is not in the allowlist. "
+            f"Add it to allowed_classes if you have verified it's safe to load."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public loader class
+# ---------------------------------------------------------------------------
+
+class SafeUnpickler:
+    """Configure a restricted unpickler once; load safely many times."""
+
+    def __init__(self, allowed_classes: Sequence[type] | None = None,
+                 exclusive: bool = False):
+        caller_set = frozenset(
+            (cls.__module__, cls.__name__) for cls in (allowed_classes or [])
+        )
+        self._allowed_globals = (
+            caller_set if exclusive else PICKLE_SAFE_TYPES | caller_set
+        )
+
+    def safe_loads(self, data: bytes):
+        return _RestrictedUnpickler(io.BytesIO(data), self._allowed_globals).load()
+
+    def safe_load(self, file_obj):
+        return self.safe_loads(file_obj.read())
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions
+# ---------------------------------------------------------------------------
+
+def safe_loads(data: bytes, allowed_classes: Sequence[type] | None = None,
+               exclusive: bool = False):
+    return SafeUnpickler(allowed_classes, exclusive).safe_loads(data)
+
+
+def safe_load(file_obj, allowed_classes: Sequence[type] | None = None,
+              exclusive: bool = False):
+    return SafeUnpickler(allowed_classes, exclusive).safe_load(file_obj)
+
+
+# ---------------------------------------------------------------------------
+# Usage demonstration
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from dataclasses import dataclass
+
+    @dataclass
+    class Order:
+        order_id: int
+        customer: str
+        amount: float
+
+    loader = SafeUnpickler(allowed_classes=[Order])
+
+    def validate_orders(raw) -> list[Order]:
+        """Validate structure and domain constraints on a loaded orders list."""
+        if not isinstance(raw, list):
+            raise TypeError(
+                f"Expected list of orders, got {type(raw).__name__}"
+            )
+        for i, order in enumerate(raw):
+            if not isinstance(order, Order):
+                raise TypeError(
+                    f"orders[{i}]: expected Order, got {type(order).__name__}"
+                )
+            if not (isinstance(order.order_id, int) and order.order_id >= 1):
+                raise ValueError(
+                    f"orders[{i}].order_id must be int >= 1, "
+                    f"got {order.order_id!r}"
+                )
+            if not (isinstance(order.customer, str) and order.customer):
+                raise ValueError(
+                    f"orders[{i}].customer must be a non-empty str"
+                )
+            if not (isinstance(order.amount, (int, float))
+                    and order.amount >= 0.0):
+                raise ValueError(
+                    f"orders[{i}].amount must be >= 0.0, "
+                    f"got {order.amount!r}"
+                )
+        return raw
+
+    print("Normal round-trip:")
+    original = Order(order_id=42, customer="Alice", amount=99.95)
+    loaded = loader.safe_loads(pickle.dumps(original))
+    print(f"  {loaded}")
+
+    print("\nLoading and validating a list of orders:")
+    orders = [
+        Order(order_id=1, customer="Alice", amount=99.95),
+        Order(order_id=2, customer="Bob", amount=0.0),
+    ]
+    validated = validate_orders(loader.safe_loads(pickle.dumps(orders)))
+    print(f"  Loaded {len(validated)} valid orders")
+    for order in validated:
+        print(f"  {order}")
+```
+
+`SafeUnpickler` configures the allowlist once and creates a fresh `_RestrictedUnpickler` for each load, which is necessary because `pickle.Unpickler` is bound to a single file at construction. The default allowlist, `PICKLE_SAFE_TYPES`, covers common built-in types, standard library value types, and exceptions frequently used in inter-process communication. Pass `allowed_classes` to permit additional application-specific types; set `exclusive=True` to restrict loading to *only* those types, bypassing `PICKLE_SAFE_TYPES` entirely.
+
+The `validate_orders` function demonstrates the required second step: after safe loading, validate both structure (is this actually a list of `Order` objects?) and domain constraints (is `order_id` a positive integer, `customer` a non-empty string, `amount` non-negative?). Each condition is written as an allowlist — `if not (correct_condition):` — so the valid range is stated explicitly rather than the invalid cases. Note that `amount` checks `isinstance(..., (int, float))` rather than just `float`, because pickle writes directly to `__dict__` and can place an `int` into an annotated `float` field without error.
+
+Before adding any class to `allowed_classes`, check the audit checklist in the `SafeUnpickler` docstring in `example02.py`. In particular, verify that `__new__`, `__setstate__`, and `__del__` do not perform dangerous operations; confirm `__reduce__`/`__reduce_ex__` cannot be exploited via the allowlist; and avoid allowlisting complex third-party classes that may contain exploitable gadget chains.
+
+## Compliant Solution JSON without pickle 1
+
+Text-based formats that have a reduced attack surface, such as `JSON`, should always be preferred over formats like `pickle` \[python.org comparison-with-json 2023\].
 
 The `compliant01.py`  code only allows serializing and deserialization of object data and not object methods as in `noncompliant01.py` or `example01.py`.
 
@@ -293,13 +521,13 @@ The `compliant01.py` stops with the unpacking with a `json.decoder.JSONDecodeErr
 
 ## Exceptions
 
-Serialized data from a trusted input source does not require sanitization, provided that the code clearly documents that it relies on the input source being trustworthy. For example, if a library is being audited, a routine of that library may have a documented precondition that its callers pre-sanitize any passed-in serialized data or confirm the input source as trustworthy.
+Serialized data from a trusted input source does not require sanitization, provided that the code clearly documents that it relies on the input source being trustworthy. For example, when writing internal library code, a routine may document a precondition that its callers must either pre-sanitize any passed-in serialized data or confirm the input source as trustworthy.
 
 ## Automated Detection
 
 |Tool|Version|Checker|Description|
 |:----|:----|:----|:----|
-|Bandit|1.7.4|B301|Pickle and modules that wrap it can be unsafe when used to de-serialize untrusted data, possible security issue.Bandit can only detect a pickle module in use and is unable to detect an acceptable implementation code that combines pickle with `hmac` and proper key management.|
+|Bandit|1.7.4|B301|Pickle and modules that wrap it can be unsafe when used to de-serialize untrusted data, possible security issue. Bandit can only detect a pickle module in use and is unable to detect an acceptable implementation code that combines pickle with `hmac` and proper key management.|
 
 ## Related Vulnerabilities
 
@@ -307,20 +535,20 @@ Serialized data from a trusted input source does not require sanitization, provi
 |:----|:----|:----|:----|:----|
 |TensorFlow using the pickle module|[CVE-2021-37678](https://www.cvedetails.com/cve/CVE-2021-37678/)|TensorFlow machine learning platform allows code execution when de-serializing a Keras model from `YAML` format.|v3.1: 8.8 High||
 |NVFLARE < 2.1.4|[CVE-2022-34668](https://www.cvedetails.com/cve/CVE-2022-34668/)|Deserialization of Untrusted Data with Pickle may allow an unprivileged network attacker to cause Remote Code Execution (RCE).|v3.1: 9.8 Critical|Exploit available on [exploit-db.com](https://www.exploit-db.com/exploits/51051)|
-|Graphite 0.9.5 through 0.9.10|[CVE-2013-5093](https://www.cvedetails.com/cve/CVE-2013-5093/)|The renderLocalView function in render/views.py uses the pickle Python module unsafely, which allows remote attackers to execute arbitrary code via a crafted serialized object|n/a|Exploit available on [exploit-db.com](https://www.exploit-db.com/exploits/27752)|
-|Superset prior to 0.23|[CVE-2018-8021](https://www.cvedetails.com/cve/CVE-2018-8021/)|TUnsafe load method from the pickle library to deserialize data leading to possible RCE|v3.1: 9.8 Critical|Exploit available on [exploit-db.com](https://www.exploit-db.com/exploits/45933)|
+|Graphite 0.9.5 through 0.9.10|[CVE-2013-5093](https://www.cvedetails.com/cve/CVE-2013-5093/)|The renderLocalView function in render/views.py uses the pickle Python module unsafely, which allows remote attackers to execute arbitrary code via a crafted serialized object|v3.1: 7.5 High|Exploit available on [exploit-db.com](https://www.exploit-db.com/exploits/27752)|
+|Superset prior to 0.23|[CVE-2018-8021](https://www.cvedetails.com/cve/CVE-2018-8021/)|Unsafe load method from the pickle library to deserialize data leading to possible RCE|v3.1: 9.8 Critical|Exploit available on [exploit-db.com](https://www.exploit-db.com/exploits/45933)|
 |rpc.py through 0.6.0|[CVE-2022-35411](https://www.cvedetails.com/cve/CVE-2022-35411/)|HTTP HEADERS set to `"serializer: pickle"` triggers `rcp.py` to de-serialize with `pickle` instead of the default `JSON` allowing Allows Remote Code Execution|v3.1:9.8 Critical|Exploit available on [https://github.com/](https://github.com/ehtec/rpcpy-exploit/blob/main/rpcpy-exploit.py)|
 
 ## Related Guidelines
 
 |||
 |:---|:---|
-|[SEI CERT Coding Standard for Java](https://wiki.sei.cmu.edu/confluence/display/java/SEI+CERT+Oracle+Coding+Standard+for+Java)|[SER01-J. Do not deviate from the proper signatures of serialization methods](https://wiki.sei.cmu.edu/confluence/display/java/SER01-J.+Do+not+deviate+from+the+proper+signatures+of+serialization+methods)|
+|[SEI CERT Coding Standard for Java](https://wiki.sei.cmu.edu/confluence/display/java/SEI+CERT+Oracle+Coding+Standard+for+Java) (shown by analogy)|[SER01-J. Do not deviate from the proper signatures of serialization methods](https://wiki.sei.cmu.edu/confluence/display/java/SER01-J.+Do+not+deviate+from+the+proper+signatures+of+serialization+methods)|
 |[MITRE CWE](http://cwe.mitre.org/)|Pillar [CWE-664: Improper Control of a Resource Through its Lifetime (4.13) (mitre.org)](https://cwe.mitre.org/data/definitions/664.html)|
 |[MITRE CWE](http://cwe.mitre.org/)|Base [CWE-502, Deserialization of Untrusted Data](http://cwe.mitre.org/data/definitions/502.html)|
 |\[Checkoway 2013\]|Checkoway, S. (2013) 'Arbitrary code execution with Python pickles', 8 October. Available from: [checkoway.net](https://checkoway.net/musings/pickle/) \[Accessed 07 May 2024\]|
 
-## Biblography
+## Bibliography
 
 |||
 |:---|:---|

--- a/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0023/example01.py
+++ b/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0023/example01.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: OpenSSF project contributors
 # SPDX-License-Identifier: MIT
-""" Compliant Code Example """
+""" Example Code: HMAC integrity protection with pickle """
 import hashlib
 import hmac
 import platform
@@ -32,7 +32,7 @@ class Preserver(object):
                 _jar (bytes): pickled jar as string
         """
         _jar = pickle.dumps(_message)
-        _digest = hmac.new(self._key, _jar, hashlib.sha256).hexdigest()
+        _digest = hmac.HMAC(self._key, _jar, hashlib.sha256).hexdigest()
         return _digest, _jar
 
     def uncan(self, _expected_digest, _jar) -> Message:
@@ -43,8 +43,8 @@ class Preserver(object):
             Returns:
                 (Message): Message object
         """
-        _digest = hmac.new(self._key, _jar, hashlib.sha256).hexdigest()
-        if _expected_digest != _digest:
+        _digest = hmac.HMAC(self._key, _jar, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(_expected_digest, _digest):
             raise ValueError("Integrity of jar compromised")
         return pickle.loads(_jar)
 

--- a/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0023/example02.py
+++ b/docs/Secure-Coding-Guide-for-Python/04_neutralization/pyscg-0023/example02.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: OpenSSF project contributors
+# SPDX-License-Identifier: MIT
+""" Example Code: secure loading of pickle data """
+
+# pickle is widely used but unsafe by default: loading a pickle stream can
+# execute arbitrary code. This module provides an allowlist-based defence:
+#
+#   Only classes explicitly approved by the caller are permitted.
+#   This blocks code execution during loading (__reduce__ exploits).
+#
+# This module controls *what kinds of objects* are allowed to load, mirroring
+# how json.loads controls what kinds of values JSON can represent. It does NOT
+# validate data values; ensuring that loaded values are safe and correct
+# remains the caller's responsibility, just as it is with json.loads.
+#
+# Quick start:
+#
+#   from example02 import SafeUnpickler
+#
+#   loader = SafeUnpickler(allowed_classes=[MyRecord])
+#   record = loader.safe_loads(raw_bytes)
+#   # validate record's field values here before use
+#
+# Run doctests:
+#
+#   python3 -m doctest example02.py
+
+import builtins
+import datetime
+import decimal
+import io
+import pickle
+import types
+import uuid
+from collections.abc import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Default allowlist
+# ---------------------------------------------------------------------------
+
+# Build the default set from concrete class objects so that module renames or
+# reimports cannot silently widen the allowlist.
+_PICKLE_SAFE_CLASSES = (
+    # Built-in primitives and containers.
+    # These cannot execute code on load, though they can carry attacker-
+    # controlled string data; always validate values after loading.
+    builtins.str, builtins.int, builtins.float, builtins.bool,
+    builtins.bytes, builtins.bytearray, type(None),
+    builtins.list, builtins.tuple, builtins.dict,
+    builtins.set, builtins.frozenset, builtins.complex,
+    builtins.range, builtins.slice,
+
+    # Immutable stdlib value types with well-defined structure.
+    datetime.date, datetime.time, datetime.datetime,
+    datetime.timedelta, datetime.timezone,
+    decimal.Decimal,
+    uuid.UUID,
+
+    # Unvalidated carriers: safe to unpickle but may hold arbitrary string
+    # data. Several exceptions included because pickle is widely used for
+    # inter-process communication (IPC) where exceptions are routinely
+    # serialized. SimpleNamespace is a common lightweight container.
+    builtins.Exception, builtins.ValueError, builtins.TypeError,
+    builtins.KeyError, builtins.IndexError, builtins.AttributeError,
+    builtins.RuntimeError,
+    types.SimpleNamespace,
+)
+
+PICKLE_SAFE_TYPES: frozenset = frozenset(
+    (cls.__module__, cls.__name__) for cls in _PICKLE_SAFE_CLASSES
+)
+"""Frozenset of ``(module, name)`` pairs considered safe to unpickle.
+
+These types cannot execute code on pickle load, but several (str, dict,
+SimpleNamespace) can carry attacker-controlled payloads that may harm
+downstream code. Always validate data values after loading.
+
+This set is public so callers can inspect it, union it with additional types,
+or ignore it entirely by passing exclusive=True to SafeUnpickler.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Internal restricted unpickler
+# ---------------------------------------------------------------------------
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that blocks every class not in allowed_globals.
+
+    Not part of the public API; use SafeUnpickler instead.
+    ``pickle.Unpickler`` is bound to one file at construction and is
+    single-use; ``SafeUnpickler`` holds the allowlist configuration and
+    creates a fresh instance of this class for each load.
+
+    pickle calls find_class() for every global (class, function, or other
+    callable) it needs to resolve while loading. By raising UnpicklingError
+    for anything outside the allowlist, we prevent __reduce__-based exploits
+    from executing their embedded callables.
+    """
+
+    def __init__(self, file, allowed_globals: frozenset):
+        super().__init__(file)
+        self._allowed_globals = allowed_globals
+
+    def find_class(self, module: str, name: str):
+        if (module, name) in self._allowed_globals:
+            mod = __import__(module, fromlist=[name])
+            return getattr(mod, name)
+        raise pickle.UnpicklingError(
+            f"Security block: '{module}.{name}' is not in the allowlist. "
+            f"Add it to allowed_classes if you have verified it's safe to load."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public loader class
+# ---------------------------------------------------------------------------
+
+class SafeUnpickler:
+    """Configure a restricted unpickler once; load safely many times.
+
+    By default the allowlist is PICKLE_SAFE_TYPES. Pass allowed_classes to
+    permit additional application-specific types. Set exclusive=True to
+    restrict loading to *only* allowed_classes, ignoring PICKLE_SAFE_TYPES;
+    use this when you want the tightest possible surface area.
+
+    Before adding a class to allowed_classes, check all of the following:
+
+    1. ``__new__``, ``__setstate__``, and ``__del__``: pickle bypasses
+       ``__init__`` but DOES call ``__new__`` and ``__setstate__`` if defined.
+       ``__del__`` (the finalizer) runs when the object is garbage-collected,
+       which can happen during or shortly after loading. Verify none of these
+       execute shell commands, file I/O, or network requests.
+
+    2. ``__reduce__`` / ``__reduce_ex__``: the primary mechanism by which
+       pickle executes arbitrary code. A class whose ``__reduce__`` returns
+       ``(callable, args)`` will have that callable invoked on load. The
+       allowlist blocks this by refusing to resolve callables not in the list,
+       but only if the callable itself is not allowlisted. Never allowlist
+       functions such as ``eval``, ``exec``, or ``os.system``.
+
+    3. Gadget chains: pickle writes loaded values directly to ``__dict__``,
+       bypassing ``__init__`` and any validation it performs. An attacker can
+       therefore set any attribute to any value they choose. If the application
+       later passes those attributes to a sensitive operation, the attacker
+       controls the outcome (even though no code ran at load time). Examples:
+
+       - A ``command: str`` field passed to ``subprocess.run(obj.command)``
+         becomes arbitrary command execution.
+       - A ``query: str`` field passed to a database cursor becomes a SQL
+         injection vector.
+       - A ``path: str`` field passed to ``open(obj.path)`` can read
+         ``/etc/passwd`` or overwrite arbitrary files.
+
+       Prefer data-only classes (dataclasses, namedtuples) whose fields are
+       never passed to system calls, file I/O, or queries without explicit
+       validation.
+
+    4. Third-party library classes: avoid allowlisting complex classes from
+       large frameworks (SQLAlchemy, NumPy, Django). They often contain deep
+       method chains that can be used as exploit gadgets.
+    """
+
+    def __init__(self, allowed_classes: Sequence[type] | None = None, exclusive: bool = False):
+        """
+        Parameters
+        ----------
+        allowed_classes:
+            List or tuple of class objects to permit. With ``exclusive=False``
+            (the default) these are *added to* PICKLE_SAFE_TYPES. With
+            ``exclusive=True`` these are the *complete* allowlist and
+            PICKLE_SAFE_TYPES is not included; you must then list every
+            type your pickle uses, including primitives such as str and int.
+        exclusive:
+            If False (the default), allowed_classes is added to
+            PICKLE_SAFE_TYPES. If True, allowed_classes is the complete
+            allowlist and PICKLE_SAFE_TYPES is not included.
+
+        Doctest: exclusive=True with the class listed permits loading::
+
+            >>> import pickle, decimal
+            >>> strict = SafeUnpickler(allowed_classes=[decimal.Decimal], exclusive=True)
+            >>> strict.safe_loads(pickle.dumps(decimal.Decimal('1.5')))
+            Decimal('1.5')
+
+        Doctest: exclusive=True blocks types that are in PICKLE_SAFE_TYPES.
+        Note: plain built-in types (dict, list, str, int) are handled by native
+        pickle opcodes and bypass find_class() entirely, so they cannot be
+        blocked by any allowlist regardless of exclusive::
+
+            >>> import pickle, datetime
+            >>> strict = SafeUnpickler(allowed_classes=[], exclusive=True)
+            >>> strict.safe_loads(  # doctest: +IGNORE_EXCEPTION_DETAIL
+            ...     pickle.dumps(datetime.date(2024, 1, 1)))
+            Traceback (most recent call last):
+                ...
+            pickle.UnpicklingError: Security block: 'datetime.date' is not in the allowlist.
+        """
+        caller_set = frozenset(
+            (cls.__module__, cls.__name__) for cls in (allowed_classes or [])
+        )
+        self._allowed_globals = (
+            caller_set if exclusive else PICKLE_SAFE_TYPES | caller_set
+        )
+
+    def safe_loads(self, data: bytes):
+        """Deserialize pickle bytes, blocking any class not in the allowlist.
+
+        Parameters
+        ----------
+        data:
+            Raw pickle bytes.
+
+        Raises
+        ------
+        pickle.UnpicklingError
+            If the pickle stream references a class outside the allowlist.
+
+        Note
+        ----
+        This method controls *what kinds of objects* are loaded, not the
+        values within them. Always validate loaded data before using it.
+
+        Doctest: ``__reduce__`` exploit is blocked::
+
+            >>> import pickle
+            >>> class Exploit:
+            ...     def __reduce__(self):
+            ...         return (eval, ('1+1',))
+            >>> SafeUnpickler().safe_loads(pickle.dumps(Exploit()))  # doctest: +IGNORE_EXCEPTION_DETAIL
+            Traceback (most recent call last):
+                ...
+            pickle.UnpicklingError: Security block: 'builtins.eval' is not in the allowlist.
+
+        Doctest: unlisted class is blocked even without a __reduce__ exploit.
+        fractions.Fraction is a real stdlib class absent from
+        PICKLE_SAFE_TYPES::
+
+            >>> import pickle, fractions
+            >>> SafeUnpickler().safe_loads(pickle.dumps(fractions.Fraction(1, 3)))  # doctest: +IGNORE_EXCEPTION_DETAIL
+            Traceback (most recent call last):
+                ...
+            pickle.UnpicklingError: Security block: 'fractions.Fraction' is not in the allowlist.
+
+        Doctest: adding a class to allowed_classes permits it to load::
+
+            >>> import pickle, fractions
+            >>> loader = SafeUnpickler(allowed_classes=[fractions.Fraction])
+            >>> loader.safe_loads(pickle.dumps(fractions.Fraction(1, 3)))
+            Fraction(1, 3)
+        """
+        return _RestrictedUnpickler(io.BytesIO(data), self._allowed_globals).load()
+
+    def safe_load(self, file_obj):
+        """Deserialize from a file-like object. Delegates to safe_loads."""
+        return self.safe_loads(file_obj.read())
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions
+# ---------------------------------------------------------------------------
+
+def safe_loads(data: bytes, allowed_classes: Sequence[type] | None = None, exclusive: bool = False):
+    """One-shot secure load from bytes.
+
+    Equivalent to::
+
+        SafeUnpickler(allowed_classes, exclusive).safe_loads(data)
+
+    Use SafeUnpickler directly when loading multiple payloads with the same
+    configuration, to avoid rebuilding the allowlist on every call.
+
+    This function controls *what kinds of objects* are loaded, not their
+    values. Always validate loaded data before use.
+    """
+    return SafeUnpickler(allowed_classes, exclusive).safe_loads(data)
+
+
+def safe_load(file_obj, allowed_classes: Sequence[type] | None = None, exclusive: bool = False):
+    """One-shot secure load from a file-like object.
+
+    Equivalent to::
+
+        SafeUnpickler(allowed_classes, exclusive).safe_load(file_obj)
+
+    This function controls *what kinds of objects* are loaded, not their
+    values. Always validate loaded data before use.
+    """
+    return SafeUnpickler(allowed_classes, exclusive).safe_load(file_obj)
+
+
+# ---------------------------------------------------------------------------
+# Usage demonstration
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from dataclasses import dataclass
+
+    @dataclass
+    class Order:
+        order_id: int
+        customer: str
+        amount: float
+
+    loader = SafeUnpickler(allowed_classes=[Order])
+
+    def validate_orders(raw) -> list[Order]:
+        """Validate structure and domain constraints on a loaded orders list."""
+        if not isinstance(raw, list):
+            raise TypeError(
+                f"Expected list of orders, got {type(raw).__name__}"
+            )
+        for i, order in enumerate(raw):
+            if not isinstance(order, Order):
+                raise TypeError(
+                    f"orders[{i}]: expected Order, got {type(order).__name__}"
+                )
+            if not (isinstance(order.order_id, int) and order.order_id >= 1):
+                raise ValueError(
+                    f"orders[{i}].order_id must be int >= 1, "
+                    f"got {order.order_id!r}"
+                )
+            if not (isinstance(order.customer, str) and order.customer):
+                raise ValueError(
+                    f"orders[{i}].customer must be a non-empty str"
+                )
+            if not (isinstance(order.amount, (int, float))
+                    and order.amount >= 0.0):
+                raise ValueError(
+                    f"orders[{i}].amount must be >= 0.0, "
+                    f"got {order.amount!r}"
+                )
+        return raw
+
+    print("Normal round-trip:")
+    original = Order(order_id=42, customer="Alice", amount=99.95)
+    loaded = loader.safe_loads(pickle.dumps(original))
+    print(f"  {loaded}")
+
+    print("\nLoading and validating a list of orders:")
+    orders = [
+        Order(order_id=1, customer="Alice", amount=99.95),
+        Order(order_id=2, customer="Bob", amount=0.0),
+    ]
+    validated = validate_orders(loader.safe_loads(pickle.dumps(orders)))
+    print(f"  Loaded {len(validated)} valid orders")
+    for order in validated:
+        print(f"  {order}")


### PR DESCRIPTION
The previous text was simple but often wrong or omitting key practical guidance. This text strongly recommends JSON (one of the few simple clearly-safe ways), then explains how to handle the many cases where people won't do that.

This notes that XML is safe, but only in some circumstances, and exaplaining how to determine if it's safe.
For example, on my system loading XML in Python is *NOT* *SAFE*, but this is something that can be programmatically determined. Also, you should consider that XML is not safe to load by default in other systems, and thus you might consider avoiding it if there are reasonable alternatives.

Similarly, YAML's `load` is *NOT* safe, you have to use `safe_load`.

Saying "don't use pickle" is true but unhelpful advice. ML is the big rage, and many models are in pickle format. So are many other data values that you need.
So yes, recommend against using pickle if at all possible. However, since people *MUST* load this format sometimes, it's important to show the painful process necessary to securely load pickle when *do* have to do it. Showing what you have to do is a better argument against pickle :-).

I wish this were simpler. However, I think it's more important to be accurate, and to explain what you have to do.