### PR TITLE
Add length parameter to os.read

### DIFF
--- a/docs/Secure-Coding-Guide-for-Python/05_exception_handling/pyscg-0015/README.md
+++ b/docs/Secure-Coding-Guide-for-Python/05_exception_handling/pyscg-0015/README.md
@@ -35,7 +35,7 @@ import uuid
 def read_file(file):
     """Function for opening a file and reading it's content."""
     fd = os.open(file, os.O_RDONLY)
-    content = os.read(fd)
+    content = os.read(fd, 1024)
     return content.decode()
  
  

--- a/docs/Secure-Coding-Guide-for-Python/05_exception_handling/pyscg-0015/noncompliant01.py
+++ b/docs/Secure-Coding-Guide-for-Python/05_exception_handling/pyscg-0015/noncompliant01.py
@@ -9,7 +9,7 @@ import uuid
 def read_file(file):
     """Function for opening a file and reading it's content."""
     fd = os.open(file, os.O_RDONLY)
-    content = os.read(fd)
+    content = os.read(fd, 1024)
     return content.decode()
 
 


### PR DESCRIPTION
Pythons os.read requires 2 parameters, but only 1 was given in the test file making it a test for missing parameters, what is not intended.