### PR TITLE
Include a link for CRA Readiness Guide For Maintainers (from OpenSSF GCP WG)

### DIFF
--- a/docs/CRA-Brief-Guide-for-OSS-Developers.md
+++ b/docs/CRA-Brief-Guide-for-OSS-Developers.md
@@ -5,6 +5,7 @@ The European Union (EU) Cyber Resilience Act (CRA) is a law that applies to soft
 Note that *this guide is not legal advice*, it’s just an overview to help you understand a few key CRA concepts. If you are looking for advice on your specific situation, please consult your own legal counsel or other detailed CRA guidance.
 
 Maintainer? Read also: [CRA Readiness Guide for Maintainers and Developers](https://policy.openssf.org/CRA/maintainers.html)
+
 ## The short version: CRA often does not apply to individual open source contributors
 
 In short, if you are contributing to others’ Open Source Software (OSS) projects, or just publish your OSS code in your own repository and you are not trying to monetize it, you do not have to *worry* about the CRA at all. As soon as you try to monetize the software as a product (such as by trying to commercially profit from the sale or support of the software product), things change.

--- a/docs/CRA-Brief-Guide-for-OSS-Developers.md
+++ b/docs/CRA-Brief-Guide-for-OSS-Developers.md
@@ -4,6 +4,7 @@ The European Union (EU) Cyber Resilience Act (CRA) is a law that applies to soft
 
 Note that *this guide is not legal advice*, it’s just an overview to help you understand a few key CRA concepts. If you are looking for advice on your specific situation, please consult your own legal counsel or other detailed CRA guidance.
 
+Maintainer? Read also: [CRA Readiness Guide for Maintainers and Developers](https://policy.openssf.org/CRA/maintainers.html)
 ## The short version: CRA often does not apply to individual open source contributors
 
 In short, if you are contributing to others’ Open Source Software (OSS) projects, or just publish your OSS code in your own repository and you are not trying to monetize it, you do not have to *worry* about the CRA at all. As soon as you try to monetize the software as a product (such as by trying to commercially profit from the sale or support of the software product), things change.


### PR DESCRIPTION

Added a note for maintainers to refer to the CRA Readiness Guide.

We have the similar cross-reference in our doc to this Guide: _Read more: [Cyber Resilience Act (CRA) Brief Guide for Open Source Software (OSS) Developers](https://best.openssf.org/CRA-Brief-Guide-for-OSS-Developers)._