### PR TITLE
Add local copies of the Compiler Annotations for C and C++ examples

### DIFF
--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/.gitignore
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/.gitignore
@@ -1,0 +1,2 @@
+noreturn-attribute
+tainted-args-attribute

--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/Makefile
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/Makefile
@@ -1,0 +1,112 @@
+# Copyright Open Source Security Foundation (OpenSSF) and its contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Each example is a local copy of the corresponding "Extended example at
+# Compiler Explorer" link in the guide. Most of the examples only declare
+# (but do not define) the annotated allocator/deallocator functions, since
+# their purpose is to show the *diagnostics* the annotations enable, not to
+# be run. Those examples are therefore only compiled to an object file
+# (linking would fail with "undefined reference"). The "noreturn" and
+# "tainted_args" examples are fully self-contained and can also be run.
+#
+# The "malloc", "access", "fd_arg"/"fd_arg_read"/"fd_arg_write", and
+# "tainted_args" examples rely on GCC's -fanalyzer or on GCC-specific
+# warnings (-Wstringop-overread, -Wstringop-overflow, -Wmismatched-dealloc)
+# that Clang does not implement, so CC must be a recent GCC (GCC 13+
+# recommended; GCC 15 was used to verify these examples) for those targets.
+# "alloc_size" and "noreturn" are portable and also build with Clang, e.g.:
+#   make CC=clang noreturn-attribute
+
+# Note: plain "?=" would not override these, since GNU Make's built-in
+# rules already assign CC/CXX a "default"-origin value of cc/g++. Using ":="
+# still allows `make CC=clang` on the command line to take precedence.
+CC  := gcc
+CXX := g++
+
+.PHONY: all clean \
+	malloc-attribute alloc-size-attribute access-attribute \
+	fd-arg-attribute noreturn-attribute tainted-args-attribute \
+	noreturn-attribute-run tainted-args-attribute-run
+
+all: malloc-attribute alloc-size-attribute access-attribute \
+	fd-arg-attribute noreturn-attribute tainted-args-attribute
+
+# "malloc" and "malloc (deallocator[, ptr-index])" attributes.
+# Compiling with -fanalyzer reports mismatched deallocation, double-free,
+# use-after-free, memory leak, and free-of-non-heap diagnostics for the
+# nonconforming functions in the file. Requires GCC 11+ for the two-argument
+# "malloc" attribute form used here.
+malloc-attribute: malloc-attribute.c
+	$(CC) -c $< -o /dev/null \
+		-Wmismatched-dealloc -fanalyzer \
+		-Wanalyzer-mismatching-deallocation \
+		-Wanalyzer-double-free \
+		-Wanalyzer-possible-null-dereference \
+		-Wanalyzer-use-after-free \
+		-Wanalyzer-malloc-leak \
+		-Wanalyzer-free-of-non-heap
+
+# "alloc_size" attribute.
+# No warnings are expected. Instead, the attribute lets __builtin_object_size
+# fold the asserts in main() to true at compile time. Compile with -O1 or
+# higher (constant folding of __builtin_object_size needs optimization) and
+# inspect the generated assembly to confirm the asserts (and the abort() call
+# behind them) are optimized away.
+alloc-size-attribute: alloc-size-attribute.c
+	$(CC) -O2 -c $< -o /dev/null
+
+alloc-size-attribute.s: alloc-size-attribute.c
+	$(CC) -O2 -S $< -o $@
+
+# "access" attribute (C++).
+# Compiling reports -Wuninitialized / -Wmaybe-uninitialized for reads of
+# uninitialized buffers and -Wstringop-overread / -Wstringop-overflow for
+# accesses that exceed the declared object size. Requires GCC 11+ (GCC
+# 10 introduced the "access" attribute itself, but these warnings improved
+# in later releases).
+access-attribute: access-attribute.cpp
+	$(CXX) -c $< -o /dev/null \
+		-Wstringop-overread -Wstringop-overflow \
+		-Wuninitialized -Wmaybe-uninitialized
+
+# "fd_arg" / "fd_arg_read" / "fd_arg_write" attributes.
+# Compiling with -fanalyzer reports access-mode mismatches, double-close,
+# use-after-close, and use-without-check diagnostics for the nonconforming
+# functions in the file. Requires GCC 13+.
+fd-arg-attribute: fd-arg-attribute.c
+	$(CC) -c $< -o /dev/null \
+		-fanalyzer \
+		-Wanalyzer-fd-access-mode-mismatch \
+		-Wanalyzer-fd-double-close \
+		-Wanalyzer-fd-leak \
+		-Wanalyzer-fd-use-after-close \
+		-Wanalyzer-fd-use-without-check
+
+# "noreturn" attribute.
+# Compiling reports that ill_be_back() is declared noreturn but falls off
+# the end of the function, plus a -Wuninitialized diagnostic for "i". This
+# example is fully defined, so it also builds a runnable executable. It
+# intentionally terminates via exit(1) inside hasta_la_vista(), so ignore
+# the resulting nonzero exit status.
+noreturn-attribute: noreturn-attribute.c
+	$(CC) -Wall $< -o $@
+
+noreturn-attribute-run: noreturn-attribute
+	-./noreturn-attribute
+
+# "tainted_args" attribute.
+# Compiling with -fanalyzer reports use of the tainted "divisor" argument
+# without a zero check. Requires GCC 12+; taint tracking is enabled by
+# default with -fanalyzer from GCC 14.1 onwards. On earlier GCC 12/13
+# releases add -fanalyzer-checker=taint explicitly. This example is fully
+# defined and reads two integers from stdin, so it can also be run, e.g.
+# with a zero divisor to trigger the division-by-zero the warning warns
+# about.
+tainted-args-attribute: tainted-args-attribute.c
+	$(CC) -fanalyzer $< -o $@
+
+tainted-args-attribute-run: tainted-args-attribute
+	printf '10\n0\n' | ./tainted-args-attribute
+
+clean:
+	rm -f noreturn-attribute tainted-args-attribute alloc-size-attribute.s *.o

--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/access-attribute.cpp
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/access-attribute.cpp
@@ -1,0 +1,56 @@
+// Copyright Open Source Security Foundation (OpenSSF) and its contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Local copy of the "access" example from
+// https://godbolt.org/z/K44d89YM7 referenced in Compiler-Annotations-for-C-and-C++.md
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+// Denotes that print_buffer will perform read-only access up to size characters on memory pointed to by buffer.
+__attribute__((access(read_only, 1, 2)))
+void print_buffer(const char *buffer, size_t size) {
+    for (size_t i = 0; i < size; ++i)
+        putchar(buffer[i]);
+}
+
+// Denotes that fill_buffer will perform write-only access up to size characters on memory pointed to by buffer.
+__attribute__((access(write_only, 1, 2)))
+void fill_buffer(char *buffer, size_t size) {
+    memset(buffer, 'a', size);
+}
+
+// Denotes that to_uppercase will perform read-write access up to size characters on memory pointed to by buffer.
+__attribute__((access(read_write, 1, 2)))
+void to_uppercase(char *buffer, size_t size) {
+    for (size_t i = 0; i < size; ++i)
+        buffer[i] = toupper((unsigned char)buffer[i]);
+}
+
+void conformant_function() {
+    char buf[256];
+    fill_buffer(buf, sizeof(buf));
+    to_uppercase(buf, sizeof(buf));
+    print_buffer(buf, sizeof(buf));
+}
+
+void nonconformant_unitialized_read_in_print_buffer() {
+    char buf[256];
+    print_buffer(buf, sizeof(buf));  // Violation: access to unitialized buffer.
+}
+
+void nonconformant_maybe_unitialized_read_write_in_to_uppercase() {
+    char buf[256];
+    to_uppercase(buf, sizeof(buf));  // Violation: Possible access to unitialized buffer.
+    print_buffer(buf, sizeof(buf));
+}
+
+void nonconformant_out_of_bounds_fill_buffer() {
+    char buf[128];
+    size_t size = 256;
+    fill_buffer(buf, size);   // Violation: Access beyond the allocated buffer size.
+    print_buffer(buf, size);  // Violation: Access beyond the allocated buffer size.
+    to_uppercase(buf, size);  // Violation: Access beyond the allocated buffer size.
+}

--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/alloc-size-attribute.c
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/alloc-size-attribute.c
@@ -1,0 +1,33 @@
+// Copyright Open Source Security Foundation (OpenSSF) and its contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Local copy of the "alloc_size" example from
+// https://godbolt.org/z/EoEWsnE7f referenced in Compiler-Annotations-for-C-and-C++.md
+
+#include <stdlib.h>
+#include <assert.h>
+
+// Denotes that my_malloc will return with a pointer to storage capable of holding up to size bytes.
+void *my_malloc(size_t size) __attribute__((alloc_size(1)));
+
+// Denotes that my_realloc will return with a pointer to storage capable of holding up to size bytes.
+void *my_realloc(void* ptr, size_t size) __attribute__((alloc_size(2)));
+
+// Denotes that my_calloc will return with a pointer to storage capable of holding up to n * size bytes.
+void *my_calloc(size_t n, size_t size) __attribute__((alloc_size(1, 2)));
+
+int main() {
+    // The following assertions will evaluate to true in both GCC and Clang
+    void *const p = my_malloc(100);
+    assert(__builtin_object_size(p, 0) == 100);
+
+    void *const q = my_calloc(20, 5);
+    assert(__builtin_object_size(q, 0) == 100);
+
+    // The following assertions will evaluate to true in GCC
+    void *r = my_malloc(100);
+    assert(__builtin_object_size(r, 0) == 100);
+
+    void *s = my_calloc(20, 5);
+    assert(__builtin_object_size(s, 0) == 100);
+}

--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/fd-arg-attribute.c
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/fd-arg-attribute.c
@@ -1,0 +1,88 @@
+// Copyright Open Source Security Foundation (OpenSSF) and its contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Local copy of the "fd_arg" / "fd_arg_read" / "fd_arg_write" example from
+// https://godbolt.org/z/T66Wj5YKv referenced in Compiler-Annotations-for-C-and-C++.md
+
+#include <fcntl.h>
+#include <unistd.h>
+
+// Denotes that use_file expects fd to be a valid and open file descriptor
+void use_file (int fd) __attribute__ ((fd_arg (1)));
+
+// Denotes that write_to_file expects fd to be a valid, open, and writable file descriptor
+void write_to_file (int fd, void *src, size_t size) __attribute__ ((fd_arg_write (1)));
+
+// Denotes that read_from_file expects fd to be a valid, open, and readable file descriptor
+void read_from_file (int fd, void *dst, size_t size) __attribute__ ((fd_arg_read (1)));
+
+
+void conforming_write_to_file(char *path, void *buf, size_t bufsize)
+{
+    int fd = open (path, O_WRONLY);
+    if (fd != -1)
+        write_to_file(fd, buf, bufsize);
+    close (fd);
+}
+
+void conforming_read_from_file(char *path, void *buf, size_t bufsize)
+{
+    int fd = open (path, O_RDONLY);
+    if (fd != -1)
+        read_from_file(fd, buf, bufsize);
+    close(fd);
+}
+
+__attribute((fd_arg(1))) void conforming_read(int old_fd, void *buf, size_t bufsize)
+{
+    if (fcntl(old_fd, F_GETFD) != -1) {
+        int fd = dup2 (old_fd, 3);
+        if (fcntl(fd, F_GETFD)) {
+            read (fd, buf, bufsize);
+            close(fd);
+        }
+    }
+}
+
+// This results in a [-Wanalyzer-fd-access-mode-mismatch] warning
+void read_from_write_only_fd(char *path, void *buf, size_t bufsize)
+{
+    int f = open (path, O_WRONLY);
+    if (f != -1)
+        read_from_file(f, buf, bufsize);
+    close (f);
+}
+
+// This results in a [-Wanalyzer-fd-access-mode-mismatch] warning
+void write_to_read_only_fd(char *path, void *buf, size_t bufsize)
+{
+    int f = open(path, O_RDONLY);
+    if (f != -1)
+        write_to_file(f, buf, bufsize);
+    close (f);
+}
+
+// This results in a [-Wanalyzer-fd-double-close] warning
+void use_file_on_double_closed_fd (char *path)
+{
+    int fd = open (path, O_RDWR);
+    if (fd != -1) {
+        use_file(fd);
+        close (fd);
+        close (fd);
+    }
+}
+
+// This results in a [-Wanalyzer-fd-use-adter-close] warning
+void use_file_on_closed_fd(int fd)
+{
+    close (fd);
+    use_file(fd);
+}
+
+// This results in a [-Wanalyzer-fd-use-without-check] warning
+void use_unchecked_fd(int old_fd)
+{
+    int fd = dup2(old_fd, 3);
+    use_file(fd);
+}

--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/malloc-attribute.c
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/malloc-attribute.c
@@ -1,0 +1,43 @@
+// Copyright Open Source Security Foundation (OpenSSF) and its contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Local copy of the "malloc" / "malloc (deallocator)" example from
+// https://godbolt.org/z/bc97ahbnd referenced in Compiler-Annotations-for-C-and-C++.md
+
+#include <stdlib.h>
+
+void my_free(void *ptr);
+
+// Denotes that my_malloc will return with a dynamically allocated piece of memory which must be freed using my_free.
+void *my_malloc(size_t size) __attribute__ ((malloc, malloc (my_free, 1)));
+
+int conforming_function() {
+    void* ptr = my_malloc(sizeof(long));
+    my_free(ptr);
+}
+
+void mismatching_deallocation() {
+    void* ptr = my_malloc(sizeof(long));
+    free(ptr);
+}
+
+void double_free() {
+    void* ptr = my_malloc(sizeof(long));
+    my_free(ptr);
+    my_free(ptr);
+}
+
+void use_after_free() {
+    long* ptr = my_malloc(sizeof(long));
+    my_free(ptr);
+    *ptr = 0;
+}
+
+void malloc_leak() {
+    long* ptr = my_malloc(sizeof(long));
+}
+
+void free_of_non_heap() {
+    long l = 0;
+    my_free((void*)&l);
+}

--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/noreturn-attribute.c
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/noreturn-attribute.c
@@ -1,0 +1,34 @@
+// Copyright Open Source Security Foundation (OpenSSF) and its contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Local copy of the "noreturn" example from
+// https://godbolt.org/z/1csnxsjrc referenced in Compiler-Annotations-for-C-and-C++.md
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// Denotes that hasta_la_vista and ill_be_back will never return
+void hasta_la_vista() __attribute__ ((noreturn));
+void ill_be_back() __attribute__ ((noreturn));
+
+void hasta_la_vista()
+{
+    printf("Hasta la vista, baby!");
+    exit (1);
+}
+
+void ill_be_back()
+{
+    printf("I'll be back...");
+}
+
+int main(int argc, char *argv[])
+{
+    int i;
+    printf("%d", i);  // Printing the unitialized i here will emit a diagnostic from [-Wuninitialized]
+
+    hasta_la_vista();
+
+    int j;
+    printf("%d", j);  // Printing the unitialized j here has been optimized away as dead code since its after a noreturn function
+}

--- a/docs/Compiler-Hardening-Guides/compiler-annotations-examples/tainted-args-attribute.c
+++ b/docs/Compiler-Hardening-Guides/compiler-annotations-examples/tainted-args-attribute.c
@@ -1,0 +1,48 @@
+// Copyright Open Source Security Foundation (OpenSSF) and its contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Local copy of the "tainted_args" example from
+// https://godbolt.org/z/rWzd68YvW referenced in Compiler-Annotations-for-C-and-C++.md
+
+#include <stdio.h>
+#include <string.h>
+
+int get_dividend();
+int get_divisor();
+
+// Denotes that the arguments to do_division contain values that must be sanitized before use
+int do_division(int dividend, int divisor) __attribute__((tainted_args));
+
+int get_dividend()
+{
+    int d;
+    printf("Enter dividend: ");
+    scanf("%d", &d);
+    return d;
+}
+
+int get_divisor()
+{
+    int d;
+    printf("Enter divisor: ");
+    scanf("%d", &d);
+    return d;
+}
+
+int do_division(int dividend, int divisor)
+{
+    return dividend / divisor;  // use of attacker-controlled value 'divisor' as divisor without checking for zero [CWE-369] [-Wanalyzer-tainted-divisor]
+}
+
+int main() {
+    int dividend, divisor, result;
+
+    dividend = get_dividend();
+    divisor = get_divisor();
+
+    result = do_division(dividend, divisor);
+
+    printf("The result is: %d\n", result);
+
+    return 0;
+}


### PR DESCRIPTION
Each example is a local copy of the corresponding "Extended example at Compiler Explorer" link in the guide. Most of the examples only declare (but do not define) the annotated allocator/deallocator functions, since their purpose is to show the *diagnostics* the annotations enable, not to be run. Those examples are therefore only compiled to an object file (linking would fail with "undefined reference"). The `noreturn` and `tainted_args` examples are fully self-contained and can also be run.