### PR TITLE
Update Dependency Graph path

### DIFF
--- a/docs/SCM-BestPractices/github/repository/ghas_dependency_review_not_enabled.md
+++ b/docs/SCM-BestPractices/github/repository/ghas_dependency_review_not_enabled.md
@@ -20,5 +20,5 @@ merge.
 
 1. Make sure you have admin permissions
 2. Go to the repo's settings page
-3. Enter "Code security and analysis" tab
+3. Enter "Advanced Security" tab
 4. Set "Dependency graph" as Enabled


### PR DESCRIPTION
The path for enabling Dependency Graph in repository settings has changed. Just keeping the documentation updated!

You can double-check this in the settings of a repository of your choice:

<img width="1366" height="618" alt="imagen" src="https://github.com/user-attachments/assets/66152a9a-56d0-4db9-98fa-2fbd0940a3ab" />
