### PR TITLE
Update Dependency Alerts path

### DIFF
--- a/docs/SCM-BestPractices/github/repository/vulnerability_alerts_not_enabled.md
+++ b/docs/SCM-BestPractices/github/repository/vulnerability_alerts_not_enabled.md
@@ -17,5 +17,5 @@ making it vulnerable to exploitation.
 
 1. Make sure you have admin permissions
 2. Go to the repo's settings page
-3. Enter "Code security and analysis" tab
+3. Enter "Advanced Security" tab
 4. Set "Dependabot alerts" as Enabled


### PR DESCRIPTION
The path for enabling Dependency Alerts in repository settings has changed. Just keeping the documentation updated!

You can double-check this in the settings of a repository of your choice:

<img width="1366" height="635" alt="imagen" src="https://github.com/user-attachments/assets/b2cfaead-178e-49a1-bd15-7bd02a808214" />
